### PR TITLE
feat: Codex service_tier パラメータを追加（fast/flex速度制御）

### DIFF
--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -165,6 +165,10 @@ ${getSupportedModelsDescription()}
                 type: 'string',
                 description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh".',
               },
+              service_tier: {
+                type: 'string',
+                description: 'Codex only. Sets service_tier for speed control. Allowed: "fast", "flex". "fast" prioritizes speed.',
+              },
               session_id: {
                 type: 'string',
                 description: 'Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview.',
@@ -282,6 +286,7 @@ ${getSupportedModelsDescription()}
         model: toolArguments.model,
         session_id: toolArguments.session_id,
         reasoning_effort: toolArguments.reasoning_effort,
+        service_tier: toolArguments.service_tier,
       });
       return {
         content: [{

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -3,6 +3,7 @@ import { resolve as pathResolve, isAbsolute } from 'node:path';
 import { MODEL_ALIASES } from './model-catalog.js';
 
 export const ALLOWED_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
+export const ALLOWED_SERVICE_TIERS = new Set(['fast', 'flex']);
 const CLAUDE_REASONING_EFFORTS = new Set(['low', 'medium', 'high']);
 
 function getAgentForModel(model: string): 'codex' | 'claude' | 'gemini' {
@@ -73,6 +74,7 @@ export interface BuildCliCommandOptions {
   model?: string;
   session_id?: string;
   reasoning_effort?: string;
+  service_tier?: string;
   cliPaths: { claude: string; codex: string; gemini: string };
 }
 
@@ -142,6 +144,25 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
 
   const reasoningEffort = getReasoningEffort(resolvedModel, reasoningEffortArg);
 
+  // Validate service_tier (Codex only)
+  let serviceTier = '';
+  if (options.service_tier && typeof options.service_tier === 'string') {
+    const normalized = options.service_tier.trim().toLowerCase();
+    if (normalized) {
+      if (!ALLOWED_SERVICE_TIERS.has(normalized)) {
+        throw new Error(
+          `Invalid service_tier: ${options.service_tier}. Allowed values: fast, flex.`
+        );
+      }
+      if (!resolvedModel.startsWith('gpt-')) {
+        throw new Error(
+          'service_tier is only supported for Codex models (gpt-*).'
+        );
+      }
+      serviceTier = normalized;
+    }
+  }
+
   // Build CLI path and args
   let cliPath: string;
   let args: string[];
@@ -157,6 +178,9 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
 
     if (reasoningEffort) {
       args.push('-c', `model_reasoning_effort=${reasoningEffort}`);
+    }
+    if (serviceTier) {
+      args.push('-c', `service_tier=${serviceTier}`);
     }
     if (resolvedModel) {
       args.push('--model', resolvedModel);


### PR DESCRIPTION
## Summary

Codex CLI の `service_tier` パラメータ（`fast` / `flex`）を MCP `run` ツールに追加しました。

Added `service_tier` parameter (`fast` / `flex`) to the MCP `run` tool for Codex CLI speed control.

## Type of Change

- [x] feat: New feature

## Changes

- `src/cli-builder.ts`: `ALLOWED_SERVICE_TIERS` 定数、バリデーション、`-c service_tier=<value>` の CLI args 追加
- `src/app/mcp.ts`: `run` ツールの inputSchema に `service_tier` プロパティ追加、`buildCliCommand()` にパススルー

### 生成されるコマンド例 / Generated command example

```bash
codex exec -c model_reasoning_effort=xhigh -c service_tier=fast --model gpt-5.4 --skip-git-repo-check --full-auto --json "prompt"
```

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [x] Manual testing: `codex-ultra` + `service_tier=fast` で正常動作確認（Windows 11）

Closes #23