### PR TITLE
fix: Windows環境で shell:true を設定し .cmd spawn を修正

### DIFF
--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -25,8 +25,9 @@ const serverStartupTime = new Date().toISOString();
 export async function spawnAsync(command: string, args: string[], options?: { timeout?: number, cwd?: string }): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     debugLog(`[Spawn] Running command: ${command} ${args.join(' ')}`);
-    const process = spawn(command, args, {
-      shell: false,
+    const useShell = process.platform === 'win32';
+    const child = spawn(command, args, {
+      shell: useShell,
       timeout: options?.timeout,
       cwd: options?.cwd,
       stdio: ['ignore', 'pipe', 'pipe']
@@ -35,13 +36,13 @@ export async function spawnAsync(command: string, args: string[], options?: { ti
     let stdout = '';
     let stderr = '';
 
-    process.stdout.on('data', (data) => { stdout += data.toString(); });
-    process.stderr.on('data', (data) => {
+    child.stdout.on('data', (data) => { stdout += data.toString(); });
+    child.stderr.on('data', (data) => {
       stderr += data.toString();
       debugLog(`[Spawn Stderr Chunk] ${data.toString()}`);
     });
 
-    process.on('error', (error: NodeJS.ErrnoException) => {
+    child.on('error', (error: NodeJS.ErrnoException) => {
       debugLog(`[Spawn Error Event] Full error object:`, error);
       let errorMessage = `Spawn error: ${error.message}`;
       if (error.path) {
@@ -54,7 +55,7 @@ export async function spawnAsync(command: string, args: string[], options?: { ti
       reject(new Error(errorMessage));
     });
 
-    process.on('close', (code) => {
+    child.on('close', (code) => {
       debugLog(`[Spawn Close] Exit code: ${code}`);
       debugLog(`[Spawn Stderr Full] ${stderr.trim()}`);
       debugLog(`[Spawn Stdout Full] ${stdout.trim()}`);

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -51,10 +51,15 @@ export class ProcessService {
     });
 
     const { cliPath, args: processArgs, cwd: effectiveCwd, agent, prompt } = cmd;
-    const childProcess = spawn(cliPath, processArgs, {
+    const isWin32 = process.platform === 'win32';
+    const spawnArgs = isWin32
+      ? processArgs.map((a: string) => a.includes(' ') ? `"${a.replace(/"/g, '\\"')}"` : a)
+      : processArgs;
+    const childProcess = spawn(cliPath, spawnArgs, {
       cwd: effectiveCwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,
+      shell: isWin32,
     });
 
     const pid = childProcess.pid;


### PR DESCRIPTION
## Summary

Windows 環境で CLI ツールが `.cmd` ファイルとしてインストールされている場合の `spawn ENOENT` エラーを修正しました。

Fixed `spawn ENOENT` error on Windows when CLI tools are installed as `.cmd` files.

## Type of Change

- [x] fix: Bug fix

## Changes

- `src/process-service.ts`: `spawn()` に `shell: process.platform === 'win32'` を追加、スペースを含む引数の自動クォート
- `src/app/mcp.ts`: `spawnAsync()` に同様の Windows shell 対応を追加

### 背景 / Context

Windows では npm グローバルインストールされた CLI ツール（claude, codex, gemini）は `.cmd` ファイルとして配置されます。Node.js の `spawn()` は `.cmd` ファイルを直接実行できないため、`shell: true` が必要です。

| Platform | CLI binary | `shell` needed? |
|----------|-----------|----------------|
| macOS/Linux | `claude` (native) | No |
| Windows | `claude.cmd` (npm shim) | **Yes** |

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [x] Manual testing: Windows 11 Enterprise LTSC 2024 で Claude/Codex 正常動作確認

Closes #24