### PR TITLE
feat: Codex デフォルトで sandbox_mode=workspace-write を設定

### DIFF
--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -158,6 +158,7 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     if (reasoningEffort) {
       args.push('-c', `model_reasoning_effort=${reasoningEffort}`);
     }
+    args.push('-c', 'sandbox_mode=workspace-write');
     if (resolvedModel) {
       args.push('--model', resolvedModel);
     }


### PR DESCRIPTION
## Summary

Codex CLI 実行時にデフォルトで `-c sandbox_mode=workspace-write` を付与し、workFolder 内のみへの書き込みに制限します。

Added `-c sandbox_mode=workspace-write` as default for all Codex CLI runs, restricting file writes to the workFolder only.

## Type of Change

- [x] feat: New feature

## Changes

- `src/cli-builder.ts`: Codex args に `args.push('-c', 'sandbox_mode=workspace-write')` を追加

### 理由 / Rationale

MCP 経由の Codex 実行は `--full-auto` で動作するため、Agent がファイルシステム全体に書き込み可能です。`sandbox_mode=workspace-write` はデフォルトの安全ガードとして、プロジェクト外への誤書き込みを防止します。

Since Codex runs via MCP use `--full-auto`, the agent can write to the entire filesystem. `sandbox_mode=workspace-write` acts as a safety guard, preventing accidental writes outside the project directory.

### トレードオフ / Trade-offs

- プロジェクト外のファイル操作が必要なタスクでは制限になる可能性があります
- 将来的に `sandbox_mode` パラメータとして MCP ツールに公開し、ユーザーが上書きできるようにすることを検討可能です

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [x] Manual testing: Codex でプロジェクト内タスクが正常動作確認

Closes #25