### PR TITLE
fix(windows): enable spawn of .cmd CLIs and quote args with whitespace

### DIFF
--- a/src/__tests__/process-management.test.ts
+++ b/src/__tests__/process-management.test.ts
@@ -3,6 +3,7 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { EventEmitter } from 'node:events';
+import { maybeQuoteWindowsArgs } from '../cli-utils.js';
 
 // Mock dependencies
 vi.mock('node:child_process');
@@ -531,10 +532,11 @@ describe('Process Management Tests', () => {
       const response = JSON.parse(result.content[0].text);
       expect(response.pid).toBe(12360);
       
-      // Verify spawn was called with the correct prompt including newlines
+      // Verify spawn was called with the correct prompt including newlines.
+      // On Windows, the args are quoted via maybeQuoteWindowsArgs to survive cmd.exe.
       expect(mockSpawn).toHaveBeenCalledWith(
         expect.any(String),
-        expect.arrayContaining(['-p', japanesePrompt]),
+        expect.arrayContaining(maybeQuoteWindowsArgs(['-p', japanesePrompt])),
         expect.any(Object)
       );
       
@@ -607,9 +609,10 @@ describe('Process Management Tests', () => {
       expect(response.pid).toBe(12361);
       
       // Verify spawn was called with the complete long prompt
+      // (Windows-quoted via maybeQuoteWindowsArgs for cmd.exe survival).
       expect(mockSpawn).toHaveBeenCalledWith(
         expect.any(String),
-        expect.arrayContaining(['-p', longJapanesePrompt]),
+        expect.arrayContaining(maybeQuoteWindowsArgs(['-p', longJapanesePrompt])),
         expect.any(Object)
       );
 
@@ -664,9 +667,10 @@ Unicodeテスト: 🎌 🗾 ✨
       expect(response.pid).toBe(12362);
       
       // Verify spawn was called with the special characters intact
+      // (Windows-quoted via maybeQuoteWindowsArgs for cmd.exe survival).
       expect(mockSpawn).toHaveBeenCalledWith(
         expect.any(String),
-        expect.arrayContaining(['-p', specialPrompt]),
+        expect.arrayContaining(maybeQuoteWindowsArgs(['-p', specialPrompt])),
         expect.any(Object)
       );
     });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -6,6 +6,7 @@ import { resolve as pathResolve } from 'node:path';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { EventEmitter } from 'node:events';
+import { maybeQuoteWindowsArgs } from '../cli-utils.js';
 
 // Mock dependencies
 vi.mock('node:child_process');
@@ -726,9 +727,10 @@ describe('ClaudeCodeServer Unit Tests', () => {
       });
       
       // Verify spawn was called with -r flag
+      // (Windows-quoted via maybeQuoteWindowsArgs for cmd.exe survival).
       expect(mockSpawn).toHaveBeenCalledWith(
         expect.any(String),
-        expect.arrayContaining(['-r', 'test-session-123', '--fork-session', '-p', 'test prompt']),
+        expect.arrayContaining(maybeQuoteWindowsArgs(['-r', 'test-session-123', '--fork-session', '-p', 'test prompt'])),
         expect.any(Object)
       );
     });
@@ -886,9 +888,10 @@ describe('ClaudeCodeServer Unit Tests', () => {
       });
       
       // Verify file was read and spawn was called with content
+      // (Windows-quoted via maybeQuoteWindowsArgs for cmd.exe survival).
       expect(mockSpawn).toHaveBeenCalledWith(
         expect.any(String),
-        expect.arrayContaining(['-p', 'Content from file']),
+        expect.arrayContaining(maybeQuoteWindowsArgs(['-p', 'Content from file'])),
         expect.any(Object)
       );
     });

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -18,7 +18,7 @@ import {
 import { join, basename, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
+import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli, quoteWindowsCmdArg } from './cli-utils.js';
 import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import { buildProcessResult } from './process-result.js';
 import {
@@ -357,11 +357,18 @@ export class CliProcessService {
     const cwdKey = this.resolveCwdKey(cmd.cwd);
     const wrapperPath = this.ensureDetachedWrapperScript();
 
-    const childProcess = spawn(wrapperPath, [this.stateDir, cwdKey, cmd.cliPath, ...cmd.args], {
-      cwd: cmd.cwd,
-      detached: true,
-      stdio: 'ignore',
-    });
+    const isWin = process.platform === 'win32';
+    const wrapperArgs = [this.stateDir, cwdKey, cmd.cliPath, ...cmd.args];
+    const childProcess = spawn(
+      isWin ? quoteWindowsCmdArg(wrapperPath) : wrapperPath,
+      isWin ? wrapperArgs.map(quoteWindowsCmdArg) : wrapperArgs,
+      {
+        cwd: cmd.cwd,
+        detached: true,
+        stdio: 'ignore',
+        shell: isWin,
+      },
+    );
 
     const pid = childProcess.pid;
     childProcess.unref();

--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -268,3 +268,17 @@ export function findClaudeCli(): string {
   const status = getCliBinaryStatus('claude');
   return getCliCommandOrThrow(status);
 }
+
+// On Windows, Node spawn({shell:true}) joins args with spaces without quoting,
+// so args containing whitespace get split by cmd.exe. We pre-quote here.
+// Uses cmd.exe convention: wrap in "..." and escape internal " as "".
+export function quoteWindowsCmdArg(arg: string): string {
+  if (arg === '') return '""';
+  if (!/[\s"&|<>^()]/.test(arg)) return arg;
+  return '"' + arg.replace(/"/g, '""') + '"';
+}
+
+export function maybeQuoteWindowsArgs(args: string[]): string[] {
+  if (process.platform !== 'win32') return args;
+  return args.map(quoteWindowsCmdArg);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { buildCliCommand } from './cli-builder.js';
-import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
+import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli, maybeQuoteWindowsArgs, quoteWindowsCmdArg } from './cli-utils.js';
 
 /**
  * Minimal argv parser. No external dependencies.
@@ -99,11 +99,17 @@ async function main(): Promise<void> {
   process.stderr.write(`[cli.run] agent=${cmd.agent} model=${cmd.resolvedModel || '(default)'}\n`);
 
   // Spawn foreground process — raw output passthrough
-  const child = spawn(cmd.cliPath, cmd.args, {
-    cwd: cmd.cwd,
-    stdio: 'inherit',
-    detached: false,
-  });
+  const isWin = process.platform === 'win32';
+  const child = spawn(
+    isWin ? quoteWindowsCmdArg(cmd.cliPath) : cmd.cliPath,
+    maybeQuoteWindowsArgs(cmd.args),
+    {
+      cwd: cmd.cwd,
+      stdio: 'inherit',
+      detached: false,
+      shell: isWin,
+    },
+  );
 
   const exitCode = await new Promise<number>((resolve) => {
     child.on('close', (code) => {

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
+import { maybeQuoteWindowsArgs, quoteWindowsCmdArg } from './cli-utils.js';
 import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import {
   appendPeekEvents,
@@ -86,11 +87,17 @@ export class ProcessService {
     });
 
     const { cliPath, args: processArgs, cwd: effectiveCwd, agent, prompt } = cmd;
-    const childProcess = spawn(cliPath, processArgs, {
-      cwd: effectiveCwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      detached: false,
-    });
+    const isWin = process.platform === 'win32';
+    const childProcess = spawn(
+      isWin ? quoteWindowsCmdArg(cliPath) : cliPath,
+      maybeQuoteWindowsArgs(processArgs),
+      {
+        cwd: effectiveCwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+        shell: isWin,
+      },
+    );
 
     const pid = childProcess.pid;
     if (!pid) {


### PR DESCRIPTION
## Summary

Fixes #24 — Windows users hit "Failed to start `<agent>` CLI process" the moment `run` is called, because `child_process.spawn` cannot directly launch the `.cmd` wrappers that npm-installed `gemini`/`codex` ship as. Adds `shell: process.platform === 'win32'` at the three spawn sites and pre-quotes args (manual cmd.exe quoting) so prompts containing whitespace (CJK, multi-word, newlines, etc.) are not split by the shell.

## Root cause

1. On Windows, `npm`-installed CLIs land as `.cmd` (and bash) wrappers, not `.exe`. Node 20+ refuses to spawn `.cmd` files without `shell: true` (CVE-2024-27980). Result: `spawn('gemini', ...)` errors out immediately, `run` returns `Failed to start gemini CLI process`, MCP server crashes on the subsequent JSON-RPC reply path.

2. Naive `shell: true` is not enough by itself. Node concatenates args with bare spaces (no auto-quoting), so a prompt like `用一句繁體中文回答：1+1 等於多少？` reaches `cmd.exe` un-quoted, gets split at the space, and `codex` rejects the trailing fragment:

   ```
   error: unexpected argument '等於多少？' found
   ```

   Gemini happens to accept multiple trailing positional args, so the bug surfaces on codex first but is real for any strict-arg CLI.

## Changes

- **`src/cli-utils.ts`** — new `quoteWindowsCmdArg()` / `maybeQuoteWindowsArgs()` helpers using cmd.exe quoting conventions (wrap in `"..."`, escape internal `"` → `""`). No-op on POSIX.
- **`src/process-service.ts:89`** — MCP `run` spawn site: `shell: process.platform === 'win32'` + pre-quoted cliPath/args.
- **`src/cli.ts:102`** — standalone CLI spawn site: same fix.
- **`src/cli-process-service.ts:360`** — detached background spawn site: same fix. (The underlying `.sh` wrapper still won't run on Windows, but the spawn no longer errors.)
- **`src/__tests__/process-management.test.ts`**, **`src/__tests__/server.test.ts`** — five `mockSpawn.toHaveBeenCalledWith(..., expect.arrayContaining([...]))` assertions wrapped in `maybeQuoteWindowsArgs(...)` so they pass on both POSIX and Windows.

## Verification

- **Windows 11 / Node 22.18** — parallel `mcp__ai-cli__run` for `gemini-2.5-flash` and `gpt-5.4-mini` both exit 0 with correct answers; prompts include CJK and embedded spaces. Without this PR both fail immediately.
- **Unit tests** — failure count drops from 26 → 21 on this branch. The remaining 21 are pre-existing Windows incompatibilities in the test infra (Unix-style mock paths in `cli-utils.test.ts`, the `.sh` detached-runner used by `cli-process-service.test.ts`, and `/tmp`-based mock CLIs in `mcp-contract.test.ts`) — **out of scope for this PR**.
- **POSIX** — no behavioral change: `shell` stays `false`, args are not transformed.

## Test plan

- [x] `npm run test:unit` on Windows: 21 baseline failures, 0 introduced by this PR (verified before/after).
- [ ] `npm run test:unit` on macOS/Linux: expected all-green; please confirm in CI.
- [x] Manual MCP `run` against real `gemini` + `codex` on Windows: both succeed.

## Notes for follow-up

The 21 remaining Windows test failures are a separate concern — fixing them probably means: (a) replacing the `.sh` detached-runner with a Windows-aware mechanism (PowerShell / .cmd shim) for `CliProcessService`, and (b) parameterizing the test fixtures so mock CLI paths use the platform-appropriate format. Happy to file a separate issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
