### PR TITLE
feat: support Antigravity and GPT-5.6 Codex variants

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -19,13 +19,13 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 
 - すべての権限確認をスキップしてClaude CLIを実行（`--dangerously-skip-permissions` を使用）
 - 承認とサンドボックスをバイパスしてCodex CLIを実行（`--dangerously-bypass-approvals-and-sandbox` を使用）
-- 自動承認モードでGemini CLIを実行（`-y` を使用）
+- Gemini エージェント経路で Antigravity CLI を print モード実行（`agy-mcp --dangerously-skip-permissions -p` を使用）
 - Forge CLI を非対話モードで実行（`forge -C <workFolder> -p <prompt>` を使用）
 - OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, haiku)
     - Codex (gpt-5.4, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2)
-    - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
+    - Gemini/Antigravity (`gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`)
     - Forge (`forge`)
     - OpenCode (`opencode` と `oc-<provider/model>` ラッパー。例: `oc-openai/gpt-5.4`)
 - PID追跡によるバックグラウンドプロセスの管理
@@ -38,7 +38,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 > 以下の3つのタスクをacm mcp runでエージェントを起動して：
 > 1. `sonnet` で `src/backend` のコードをリファクタリング
 > 2. `gpt-5.3-codex` で `src/frontend` のユニットテストを作成
-> 3. `gemini-2.5-pro` で `docs/` のドキュメントを更新
+> 3. `gemini-3.5-flash-high` で `docs/` のドキュメントを更新
 >
 > 実行中はあなたはTODOリストを更新する作業を行ってください。それが終わったら `wait` ツールを使ってすべての完了を待機し、結果をまとめて報告してください。
 
@@ -67,7 +67,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 
 - **Claude Code**: `claude doctor` が通り、`--dangerously-skip-permissions` での実行が承認済み（一度手動で実行してログイン・承認済み）であること。
 - **Codex CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。
-- **Gemini CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。
+- **Antigravity CLI**（オプション）: `agy-mcp` がインストール済みで、初期設定が完了していること。
 - **Forge CLI**（オプション）: インストール済みで、初期設定が完了していること。
 - **OpenCode**（オプション）: インストール済みで、設定が完了していること。この統合では `opencode run --format json` を使用し、明示的なモデル指定は `ai-cli models` が公開する `oc-<provider/model>` 構文に従います。
 
@@ -162,12 +162,12 @@ claude --dangerously-skip-permissions
 codex login
 ```
 
-### Gemini CLIの場合:
+### Antigravity CLIの場合:
 
-**Geminiの場合、ログインして認証情報を設定していることを確認してください：**
+**Antigravity のモデル一覧を取得できることを確認してください：**
 
 ```bash
-gemini auth login
+agy-mcp models
 ```
 
 macOSでは、これらのツールを初めて実行する際にフォルダへのアクセス許可を求められる場合があります。最初の実行が失敗しても、2回目以降は動作するはずです。
@@ -252,7 +252,7 @@ detached 実行された `ai-cli` は、すべての対応バックエンドで�
 
 ### `run`
 
-Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用してプロンプトを実行します。モデル名に基づいて適切なCLIが自動的に選択されます。
+Claude CLI、Codex CLI、Gemini エージェント経路の Antigravity CLI、Forge CLI、または OpenCode を使用してプロンプトを実行します。モデル名に基づいて適切なCLIが自動的に選択されます。
 
 **引数:**
 - `prompt` (string, 任意): AIエージェントに送信するプロンプト。`prompt` または `prompt_file` のいずれかが必須です。
@@ -262,7 +262,7 @@ Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用�
     - **Ultra エイリアス:** `claude-ultra` (自動的に max effort に設定), `codex-ultra` (`gpt-5.5`、自動的に xhigh reasoning に設定), `gemini-ultra`
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
     - Codex: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
-    - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+    - Gemini/Antigravity: `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`
     - Forge: `forge`
     - OpenCode: `opencode`（設定済みのデフォルトモデル）および `oc-openai/gpt-5.4` のような明示ラッパー
 - `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high", "xhigh", "max"）。Codex では `model_reasoning_effort` を使います（許容値: "low", "medium", "high", "xhigh"）。Gemini、Forge、OpenCode では `reasoning_effort` はサポートしません。
@@ -414,7 +414,7 @@ live E2E は opt-in です。インストール済みかつ認証済みの外部
 
 - `CLAUDE_CLI_NAME`: Claude CLIのバイナリ名または絶対パスを上書き（デフォルト: `claude`）
 - `CODEX_CLI_NAME`: Codex CLIのバイナリ名または絶対パスを上書き（デフォルト: `codex`）
-- `GEMINI_CLI_NAME`: Gemini CLIのバイナリ名または絶対パスを上書き（デフォルト: `gemini`）
+- `GEMINI_CLI_NAME`: Gemini/Antigravity CLIのバイナリ名または絶対パスを上書き（デフォルト: `agy-mcp`）
 - `FORGE_CLI_NAME`: Forge CLIのバイナリ名または絶対パスを上書き（デフォルト: `forge`）
 - `OPENCODE_CLI_NAME`: OpenCode CLIのバイナリ名または絶対パスを上書き（デフォルト: `opencode`）
 - `MCP_CLAUDE_DEBUG`: デバッグログを有効化（`true` に設定すると詳細な出力が表示されます）

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, haiku)
-    - Codex (gpt-5.4, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2)
+    - Codex (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2)
     - Gemini/Antigravity (`gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`)
     - Forge (`forge`)
     - OpenCode (`opencode` と `oc-<provider/model>` ラッパー。例: `oc-openai/gpt-5.4`)
@@ -66,7 +66,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 利用したいAI CLIツールがローカル環境にインストールされ、正しく設定されていることが唯一の前提条件です。
 
 - **Claude Code**: `claude doctor` が通り、`--dangerously-skip-permissions` での実行が承認済み（一度手動で実行してログイン・承認済み）であること。
-- **Codex CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。
+- **Codex CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。GPT-5.6 Sol/Terra/Luna には Codex CLI `>= 0.144.0` が必要です。
 - **Antigravity CLI**（オプション）: `agy-mcp` がインストール済みで、初期設定が完了していること。
 - **Forge CLI**（オプション）: インストール済みで、初期設定が完了していること。
 - **OpenCode**（オプション）: インストール済みで、設定が完了していること。この統合では `opencode run --format json` を使用し、明示的なモデル指定は `ai-cli models` が公開する `oc-<provider/model>` 構文に従います。
@@ -259,14 +259,16 @@ Claude CLI、Codex CLI、Gemini エージェント経路の Antigravity CLI、Fo
 - `prompt_file` (string, 任意): プロンプトを含むファイルへのパス。`prompt` または `prompt_file` のいずれかが必須です。絶対パス、または `workFolder` からの相対パスが指定可能です。
 - `workFolder` (string, 必須): CLIを実行する作業ディレクトリ。絶対パスである必要があります。
 - **モデル (Models):**
-    - **Ultra エイリアス:** `claude-ultra` (自動的に max effort に設定), `codex-ultra` (`gpt-5.5`、自動的に xhigh reasoning に設定), `gemini-ultra`
+    - **Ultra エイリアス:** `claude-ultra` (自動的に max effort に設定), `codex-ultra` (`gpt-5.6-sol`、自動的に ultra reasoning に設定), `gemini-ultra`
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-    - Codex: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
+    - Codex: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
     - Gemini/Antigravity: `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`
     - Forge: `forge`
     - OpenCode: `opencode`（設定済みのデフォルトモデル）および `oc-openai/gpt-5.4` のような明示ラッパー
-- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high", "xhigh", "max"）。Codex では `model_reasoning_effort` を使います（許容値: "low", "medium", "high", "xhigh"）。Gemini、Forge、OpenCode では `reasoning_effort` はサポートしません。
+- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude は `--effort` で `low` から `max` を使用します。GPT-5.6 Sol/Terra/Luna と Codex の設定済みデフォルトは `model_reasoning_effort` で `low`, `medium`, `high`, `xhigh`, `max`, `ultra` を使用でき、明示的な旧 Codex モデルは `xhigh` までです。Gemini、Forge、OpenCode では `reasoning_effort` はサポートしません。
 - `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。Claude、Codex、Gemini、Forge、OpenCode でサポートされます。OpenCode は `--session` による in-place resume で再開し、`oc-<provider/model>` の明示指定と併用できます。
+
+> **移行メモ:** `codex-ultra` は以前 `gpt-5.5` + `xhigh` でしたが、現在は最強の Codex オプションとして `gpt-5.6-sol` + `ultra` を指します。旧動作が必要な場合は `model: "gpt-5.5"` と `reasoning_effort: "xhigh"` を明示してください。Codex CLI 0.144.0 の表示カタログは Luna の `ultra` を省略していますが、2026-07-09 の互換性確認でバックエンドが `gpt-5.6-luna` + `ultra` を受理して報告することを確認済みです。
 
 ### `wait`
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 
 - Run Claude CLI with all permissions bypassed (using `--dangerously-skip-permissions`)
 - Execute Codex CLI with approvals and sandbox bypassed (using `--dangerously-bypass-approvals-and-sandbox`)
-- Execute Gemini CLI with automatic approval mode (using `-y`)
+- Execute Antigravity CLI through the Gemini agent path in print mode (using `agy-mcp --dangerously-skip-permissions -p`)
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
 - Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini/Antigravity (`gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -35,7 +35,7 @@ You can instruct your main agent to run multiple tasks in parallel like this:
 > Launch agents for the following 3 tasks using acm mcp run:
 > 1. Refactor `src/backend` code using `sonnet`
 > 2. Create unit tests for `src/frontend` using `gpt-5.3-codex`
-> 3. Update docs in `docs/` using `gemini-2.5-pro`
+> 3. Update docs in `docs/` using `gemini-3.5-flash-high`
 >
 > While they run, please update the TODO list. Once done, use the `wait` tool to wait for all completions and report the results together.
 
@@ -64,7 +64,7 @@ The only prerequisite is that the AI CLI tools you want to use are locally insta
 
 - **Claude Code**: `claude doctor` passes, and execution with `--dangerously-skip-permissions` is approved (you must run it manually once to login and accept terms).
 - **Codex CLI** (Optional): Installed and initial setup (login etc.) completed.
-- **Gemini CLI** (Optional): Installed and initial setup (login etc.) completed.
+- **Antigravity CLI** (Optional): `agy-mcp` installed and initial setup completed.
 - **Forge CLI** (Optional): Installed and initial setup completed.
 - **OpenCode** (Optional): Installed and configured. This integration uses `opencode run --format json`, and explicit provider/model selection follows the `oc-<provider/model>` wrapper syntax exposed by `ai-cli models`.
 
@@ -159,12 +159,12 @@ Follow the prompts to accept. Once this is done, the MCP server will be able to 
 codex login
 ```
 
-### For Gemini CLI:
+### For Antigravity CLI:
 
-**For Gemini, ensure you're logged in and have configured your credentials:**
+**For Antigravity, ensure the CLI can resolve available models:**
 
 ```bash
-gemini auth login
+agy-mcp models
 ```
 
 macOS might ask for folder permissions the first time any of these tools run. If the first run fails, subsequent runs should work.
@@ -249,7 +249,7 @@ This server exposes the following tools:
 
 ### `run`
 
-Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, Forge CLI, or OpenCode. The appropriate CLI is automatically selected based on the model name.
+Executes a prompt using Claude CLI, Codex CLI, Antigravity through the Gemini agent path, Forge CLI, or OpenCode. The appropriate CLI is automatically selected based on the model name.
 
 **Arguments:**
 - `prompt` (string, optional): The prompt to send to the AI agent. Either `prompt` or `prompt_file` is required.
@@ -259,7 +259,7 @@ Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, Forge CLI, or OpenCod
 - **Ultra Aliases:** `claude-ultra` (defaults to max effort), `codex-ultra` (`gpt-5.5`, defaults to xhigh reasoning), `gemini-ultra`
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
 - Codex: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
-- Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+- Gemini/Antigravity: `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`
 - Forge: `forge`
 - OpenCode: `opencode` for the configured default backend model, plus explicit wrappers like `oc-openai/gpt-5.4`
 - `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high", "xhigh", "max"). Codex uses `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh"). Gemini, Forge, and OpenCode do not support `reasoning_effort`.
@@ -404,7 +404,7 @@ Normally not required, but useful for customizing CLI paths or debugging.
 
 - `CLAUDE_CLI_NAME`: Override the Claude CLI binary name or provide an absolute path (default: `claude`)
 - `CODEX_CLI_NAME`: Override the Codex CLI binary name or provide an absolute path (default: `codex`)
-- `GEMINI_CLI_NAME`: Override the Gemini CLI binary name or provide an absolute path (default: `gemini`)
+- `GEMINI_CLI_NAME`: Override the Gemini/Antigravity CLI binary name or provide an absolute path (default: `agy-mcp`)
 - `FORGE_CLI_NAME`: Override the Forge CLI binary name or provide an absolute path (default: `forge`)
 - `OPENCODE_CLI_NAME`: Override the OpenCode CLI binary name or provide an absolute path (default: `opencode`)
 - `MCP_CLAUDE_DEBUG`: Enable debug logging (set to `true` for verbose output)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 - Execute Antigravity CLI through the Gemini agent path in print mode (using `agy-mcp --dangerously-skip-permissions -p`)
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
 - Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini/Antigravity (`gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini/Antigravity (`gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -63,7 +63,7 @@ You can reuse heavy context (like large codebases) using session IDs to save cos
 The only prerequisite is that the AI CLI tools you want to use are locally installed and correctly configured.
 
 - **Claude Code**: `claude doctor` passes, and execution with `--dangerously-skip-permissions` is approved (you must run it manually once to login and accept terms).
-- **Codex CLI** (Optional): Installed and initial setup (login etc.) completed.
+- **Codex CLI** (Optional): Installed and initial setup (login etc.) completed. GPT-5.6 Sol/Terra/Luna support requires Codex CLI `>= 0.144.0`.
 - **Antigravity CLI** (Optional): `agy-mcp` installed and initial setup completed.
 - **Forge CLI** (Optional): Installed and initial setup completed.
 - **OpenCode** (Optional): Installed and configured. This integration uses `opencode run --format json`, and explicit provider/model selection follows the `oc-<provider/model>` wrapper syntax exposed by `ai-cli models`.
@@ -256,14 +256,16 @@ Executes a prompt using Claude CLI, Codex CLI, Antigravity through the Gemini ag
 - `prompt_file` (string, optional): Path to a file containing the prompt. Either `prompt` or `prompt_file` is required. Can be absolute path or relative to `workFolder`.
 - `workFolder` (string, required): The working directory for the CLI execution. Must be an absolute path.
 **Models:**
-- **Ultra Aliases:** `claude-ultra` (defaults to max effort), `codex-ultra` (`gpt-5.5`, defaults to xhigh reasoning), `gemini-ultra`
+- **Ultra Aliases:** `claude-ultra` (defaults to max effort), `codex-ultra` (`gpt-5.6-sol`, defaults to ultra reasoning), `gemini-ultra`
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-- Codex: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
+- Codex: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
 - Gemini/Antigravity: `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`
 - Forge: `forge`
 - OpenCode: `opencode` for the configured default backend model, plus explicit wrappers like `oc-openai/gpt-5.4`
-- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high", "xhigh", "max"). Codex uses `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh"). Gemini, Forge, and OpenCode do not support `reasoning_effort`.
+- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (`low` through `max`). GPT-5.6 Sol/Terra/Luna and the configured Codex default use `model_reasoning_effort` (`low`, `medium`, `high`, `xhigh`, `max`, `ultra`); explicit legacy Codex models remain limited to `low` through `xhigh`. Gemini, Forge, and OpenCode do not support `reasoning_effort`.
 - `session_id` (string, optional): Optional session ID to resume a previous session. Supported for Claude, Codex, Gemini, Forge, and OpenCode. OpenCode resumes in place via `--session` and may also be combined with an explicit `oc-<provider/model>` selection.
+
+> **Migration note:** `codex-ultra` previously resolved to `gpt-5.5` + `xhigh`; it now tracks the strongest Codex option as `gpt-5.6-sol` + `ultra`. Pin `model: "gpt-5.5"` and `reasoning_effort: "xhigh"` when the old behavior is required. Codex CLI 0.144.0's visual model catalog omits `ultra` for Luna, but the backend accepted and reported `gpt-5.6-luna` + `ultra` in a live compatibility check on 2026-07-09.
 
 ### `wait`
 

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -7,7 +7,7 @@
 - `ai-cli`: human-facing production CLI
 - `ai-cli-mcp`: MCP server entrypoint for backward compatibility
 
-The package name stays `ai-cli-mcp` for now. We do not introduce a daemon. We keep the product as a thin wrapper over Claude Code, Codex CLI, and Gemini CLI.
+The package name stays `ai-cli-mcp` for now. We do not introduce a daemon. We keep the product as a thin wrapper over Claude Code, Codex CLI, and Antigravity CLI through the existing Gemini agent path.
 
 ## Non-Goals
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -122,11 +122,13 @@ src/
 
 ```
 claude-ultra  → opus (+ reasoning_effort: max)
-codex-ultra   → gpt-5.5 (+ reasoning_effort: xhigh)
+codex-ultra   → gpt-5.6-sol (+ reasoning_effort: ultra)
 gemini-ultra  → Gemini 3.1 Pro (High)
 ```
 
 **設計意図**: AI プロバイダーのモデル名は頻繁に変わる。利用者（特にAIエージェント）が個々のモデル名の変遷を追う必要がないよう、「そのプロバイダーの最強モデル」を指す安定したエイリアスを提供する。マッピング先はサーバー側で更新するだけで、利用者のプロンプトを変更する必要がない。
+
+`codex-ultra` はこの設計に従って `gpt-5.5` + `xhigh` から `gpt-5.6-sol` + `ultra` へ移行した。再現性のため旧モデルを固定したい呼び出しは、エイリアスではなくモデルと effort を明示する。
 
 ## Security Model
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -27,7 +27,7 @@ MCP Client (Cursor, Claude Code, etc.)
   │
   ├─ run(prompt, model="opus")     → PID 1234 (即座に返却)
   ├─ run(prompt, model="gpt-5.3-codex")  → PID 1235
-  ├─ run(prompt, model="gemini-2.5-pro") → PID 1236
+  ├─ run(prompt, model="gemini-3.5-flash-high") → PID 1236
   │
   ├─ list_processes()  → 実行状況一覧
   ├─ peek(pids)        → 実行中出力の短時間観測
@@ -62,13 +62,13 @@ wait([PID 1, 2, 3]) → ブロック → 全完了後に結果をまとめて返
 
 ### 1. どのAI CLIからでも同じプロンプトで使える
 
-このMCPサーバーは Claude Code / Gemini CLI / Codex CLI のいずれをホスト（呼び出し元）としても、同じツール名・同じ引数・同じプロンプトで動作する。ホスト側のAIがどのプロバイダーであっても、統一されたMCPインターフェースを通じて同一の体験を提供する。
+このMCPサーバーは Claude Code / Gemini エージェント経路の Antigravity CLI / Codex CLI のいずれをホスト（呼び出し元）としても、同じツール名・同じ引数・同じプロンプトで動作する。ホスト側のAIがどのプロバイダーであっても、統一されたMCPインターフェースを通じて同一の体験を提供する。
 
 ### 2. CLI差異の完全な隠蔽
 
 利用者（主にAIエージェント）は Claude Code / Codex / Gemini の個別仕様を一切知る必要がない。
 
-- パーミッションフラグの違い（`--dangerously-skip-permissions` / `--full-auto` / `-y`）
+- パーミッションフラグの違い（`--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox`）
 - 出力形式の違い（Claude の JSON / Codex のログ / Gemini の出力）
 - セッション管理の違い（`--session-id` / `--session` / `-s`）
 - モデル名の指定方法の違い
@@ -123,7 +123,7 @@ src/
 ```
 claude-ultra  → opus (+ reasoning_effort: max)
 codex-ultra   → gpt-5.5 (+ reasoning_effort: xhigh)
-gemini-ultra  → gemini-3.1-pro-preview
+gemini-ultra  → Gemini 3.1 Pro (High)
 ```
 
 **設計意図**: AI プロバイダーのモデル名は頻繁に変わる。利用者（特にAIエージェント）が個々のモデル名の変遷を追う必要がないよう、「そのプロバイダーの最強モデル」を指す安定したエイリアスを提供する。マッピング先はサーバー側で更新するだけで、利用者のプロンプトを変更する必要がない。
@@ -133,8 +133,8 @@ gemini-ultra  → gemini-3.1-pro-preview
 このツールは **信頼された環境でのみ使用する** ことを前提としている。
 
 - Claude Code は `--dangerously-skip-permissions` で実行される（すべてのファイル操作・コマンド実行が無許可で行われる）
-- Codex は `--full-auto` で実行される
-- Gemini は `-y`（自動承認）で実行される
+- Codex は `--dangerously-bypass-approvals-and-sandbox` で実行される
+- Gemini エージェント経路の Antigravity は `--dangerously-skip-permissions -p` で実行される
 
 つまり、このMCPサーバーに接続できるクライアントは、ローカルマシン上で **任意のコード実行が可能** である。ネットワーク越しの不特定多数への公開や、信頼できないクライアントからのアクセスは想定していない。
 
@@ -153,7 +153,7 @@ gemini-ultra  → gemini-3.1-pro-preview
 |---|---|
 | `node:child_process.spawn` でプロセス管理 | 軽量で直接的。外部依存なしにPIDベースの管理が可能 |
 | `--dangerously-skip-permissions` (Claude) | MCP経由の自動実行には非対話モードが必須 |
-| `--full-auto` (Codex) / `-y` (Gemini) | 同上。各CLIの自動承認モード |
+| `--dangerously-bypass-approvals-and-sandbox` (Codex) / `--dangerously-skip-permissions -p` (Antigravity) | 同上。各CLIの自動承認・非対話モード |
 | `session_id` サポート | コンテキストキャッシュにより、大規模コードベースの読み込みコストを複数タスクで共有 |
 | 出力パーサーの分離 | CLI出力形式の変更に対して個別に対応可能 |
 | npx 配布 | インストール不要でMCP設定に直接記述可能 |

--- a/docs/development.md
+++ b/docs/development.md
@@ -147,12 +147,12 @@ This will open a web interface where you can:
 3. Test different AI models including:
    - Claude models: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
    - Codex models: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
-   - Gemini models: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+   - Gemini/Antigravity models: `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`
 
 Example test: Select the `run` tool and provide:
 - `prompt`: "What is 2+2?"
 - `workFolder`: "/tmp"
-- `model`: "gemini-2.5-flash"
+- `model`: "gemini-3.5-flash"
 
 ## Configuration via Environment Variables
 
@@ -160,7 +160,7 @@ Example test: Select the `run` tool and provide:
 |----------|-------------|
 | `CLAUDE_CLI_NAME` | Claude CLI binary name or absolute path (default: `claude`) |
 | `CODEX_CLI_NAME` | Codex CLI binary name or absolute path (default: `codex`) |
-| `GEMINI_CLI_NAME` | Gemini CLI binary name or absolute path (default: `gemini`) |
+| `GEMINI_CLI_NAME` | Gemini/Antigravity CLI binary name or absolute path (default: `agy-mcp`) |
 | `MCP_CLAUDE_DEBUG` | Enable debug logging — `true` / `false` (default: `false`) |
 
 These can be set in your shell environment or within the `env` block of your `mcp.json` server configuration.

--- a/docs/development.md
+++ b/docs/development.md
@@ -146,7 +146,8 @@ This will open a web interface where you can:
 2. Test each tool with different parameters
 3. Test different AI models including:
    - Claude models: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-   - Codex models: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
+   - Codex models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
+   - GPT-5.6 reasoning (Codex CLI `>= 0.144.0`): `low`, `medium`, `high`, `xhigh`, `max`, `ultra`; explicit legacy Codex models: through `xhigh`
    - Gemini/Antigravity models: `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low`
 
 Example test: Select the `run` tool and provide:

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -108,7 +108,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 | Provider | Models |
 |---|---|
 | Claude | `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku` |
-| Codex | `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` |
+| Codex | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` |
 | Gemini/Antigravity | `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low` |
 | Ultra aliases | `claude-ultra`, `codex-ultra`, `gemini-ultra` |
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -20,7 +20,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 
 ## Goals
 
-- **ホスト非依存**: Claude Code / Gemini CLI / Codex CLI のどれをホスト（呼び出し元）として使っても、同じプロンプト・同じインターフェースで動作すること
+- **ホスト非依存**: Claude Code / Gemini エージェント経路の Antigravity CLI / Codex CLI のどれをホスト（呼び出し元）として使っても、同じプロンプト・同じインターフェースで動作すること
 - **CLI差異の隠蔽**: 利用者が呼び出し先の Claude Code / Codex / Gemini の個別仕様（フラグ、出力形式、セッション管理等）を意識せず、モデル名とプロンプトだけで使えること
 - **AI-Friendly な返り値**: 各CLIの生出力をパースし、AIエージェントが次のアクションを判断しやすい構造化データとして返すこと
 - **並行実行**: MCP対応の任意のクライアントから、複数のAI CLIエージェントを並行実行できること
@@ -109,7 +109,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 |---|---|
 | Claude | `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku` |
 | Codex | `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` |
-| Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
+| Gemini/Antigravity | `gemini-3.5-flash-high`, `gemini-3.5-flash`, `gemini-3.5-flash-low`, `gemini-3.1-pro`, `gemini-3.1-pro-low` |
 | Ultra aliases | `claude-ultra`, `codex-ultra`, `gemini-ultra` |
 
 ## User Scenarios
@@ -138,7 +138,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 
 本プロダクトは **信頼されたローカル環境** での使用を前提とする。
 
-- 各AI CLIは自動承認モード（`--dangerously-skip-permissions` / `--full-auto` / `-y`）で実行されるため、接続クライアントはローカルマシン上で任意のコード実行が可能になる
+- 各AI CLIは自動承認モード（`--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox`）で実行されるため、接続クライアントはローカルマシン上で任意のコード実行が可能になる
 - ネットワーク越しの不特定多数への公開は想定しない
 - セキュリティ境界は「MCPサーバーへの接続可否」で制御される
 

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -409,7 +409,7 @@ describe('ai-cli app', () => {
     expect(stdout).toHaveBeenCalledWith(RUN_HELP_TEXT);
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('claude-ultra'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.3-codex'));
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gemini-2.5-pro'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gemini-3.5-flash-high'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('forge'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('opencode'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('oc-openai/gpt-5.4'));

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -309,20 +309,32 @@ describe('ai-cli app', () => {
         }),
         expect.objectContaining({
           name: 'codex-ultra',
-          resolvesTo: 'gpt-5.5',
+          resolvesTo: 'gpt-5.6-sol',
           agent: 'codex',
-          defaultReasoningEffort: 'xhigh',
+          defaultReasoningEffort: 'ultra',
         }),
       ])
     );
     expect(payload.claude).toContain('sonnet');
     expect(payload.codex).not.toContain('codex');
+    expect(payload.codex).toContain('gpt-5.6-sol');
+    expect(payload.codex).toContain('gpt-5.6-terra');
+    expect(payload.codex).toContain('gpt-5.6-luna');
     expect(payload.codex).toContain('gpt-5.4');
     expect(payload.codex).toContain('gpt-5.5');
     expect(payload.codex).toContain('gpt-5.4-mini');
     expect(payload.codex).toContain('gpt-5.3-codex');
     expect(payload.codex).toContain('gpt-5.3-codex-spark');
     expect(payload.codex).toContain('gpt-5.2');
+    expect(payload.codexMinimumCliVersionForGpt56).toBe('0.144.0');
+    expect(payload.codexReasoningEfforts.legacyDefault).toEqual([
+      'low', 'medium', 'high', 'xhigh',
+    ]);
+    for (const model of ['codex', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+      expect(payload.codexReasoningEfforts.byModel[model]).toEqual([
+        'low', 'medium', 'high', 'xhigh', 'max', 'ultra',
+      ]);
+    }
     expect(payload.forge).toEqual(['forge']);
     expect(payload.opencode).toEqual(['opencode']);
     expect(payload.dynamicModelBackends).toEqual({
@@ -408,7 +420,8 @@ describe('ai-cli app', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toHaveBeenCalledWith(RUN_HELP_TEXT);
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('claude-ultra'));
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.3-codex'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.6-sol'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('low..ultra'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gemini-3.5-flash-high'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('forge'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('opencode'));

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -42,8 +42,8 @@ describe('cli-builder', () => {
       expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.5');
     });
 
-    it('should resolve gemini-ultra to gemini-3.1-pro-preview', () => {
-      expect(resolveModelAlias('gemini-ultra')).toBe('gemini-3.1-pro-preview');
+    it('should resolve gemini-ultra to Gemini 3.1 Pro (High)', () => {
+      expect(resolveModelAlias('gemini-ultra')).toBe('Gemini 3.1 Pro (High)');
     });
 
     it('should pass through non-alias model names', () => {
@@ -97,7 +97,7 @@ describe('cli-builder', () => {
     });
 
     it('should throw for unsupported model families', () => {
-      expect(() => getReasoningEffort('gemini-2.5-pro', 'high')).toThrow(
+      expect(() => getReasoningEffort('gemini-3.5-flash-high', 'high')).toThrow(
         'reasoning_effort is only supported for Claude and Codex models.'
       );
     });
@@ -450,35 +450,65 @@ describe('cli-builder', () => {
       });
     });
 
-    describe('gemini agent', () => {
-      it('should build gemini command', () => {
+    describe('gemini agent (Antigravity CLI / agy)', () => {
+      it('should build gemini command with agy yolo flags', () => {
         const cmd = buildCliCommand({
           prompt: 'test',
           workFolder: '/tmp',
-          model: 'gemini-2.5-pro',
+          model: 'gemini-3.5-flash-high',
           cliPaths: DEFAULT_CLI_PATHS,
         });
 
         expect(cmd.agent).toBe('gemini');
         expect(cmd.cliPath).toBe('/usr/bin/gemini');
-        expect(cmd.args).toContain('-y');
-        expect(cmd.args).toContain('--output-format');
-        expect(cmd.args).toContain('stream-json');
+        expect(cmd.args).toContain('--dangerously-skip-permissions');
         expect(cmd.args).toContain('--model');
-        expect(cmd.args).toContain('gemini-2.5-pro');
+        expect(cmd.args).toContain('Gemini 3.5 Flash (High)');
+        expect(cmd.args).toContain('-p');
+        expect(cmd.args).toContain('test');
+        // agy NÃO usa as flags do gemini-cli legado.
+        expect(cmd.args).not.toContain('-y');
+        expect(cmd.args).not.toContain('--output-format');
+        expect(cmd.args).not.toContain('stream-json');
       });
 
-      it('should build gemini command with session_id', () => {
+      it('should accept the display-name model directly', () => {
         const cmd = buildCliCommand({
           prompt: 'test',
           workFolder: '/tmp',
-          model: 'gemini-2.5-pro',
+          model: 'Gemini 3.5 Flash (High)',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.agent).toBe('gemini');
+        expect(cmd.resolvedModel).toBe('Gemini 3.5 Flash (High)');
+      });
+
+      it('should resume via --conversation with session_id', () => {
+        const cmd = buildCliCommand({
+          prompt: 'test',
+          workFolder: '/tmp',
+          model: 'gemini-3.5-flash-high',
           session_id: 'gem-789',
           cliPaths: DEFAULT_CLI_PATHS,
         });
 
-        expect(cmd.args).toContain('-r');
+        expect(cmd.args).toContain('--conversation');
         expect(cmd.args).toContain('gem-789');
+        expect(cmd.args).not.toContain('-r');
+      });
+
+      it('should pass internal agy log file path when provided', () => {
+        const cmd = buildCliCommand({
+          prompt: 'test',
+          workFolder: '/tmp',
+          model: 'gemini-3.5-flash-high',
+          log_file: '/tmp/agy.log',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.args).toContain('--log-file');
+        expect(cmd.args).toContain('/tmp/agy.log');
       });
 
       it('should resolve gemini-ultra alias', () => {
@@ -490,7 +520,7 @@ describe('cli-builder', () => {
         });
 
         expect(cmd.agent).toBe('gemini');
-        expect(cmd.resolvedModel).toBe('gemini-3.1-pro-preview');
+        expect(cmd.resolvedModel).toBe('Gemini 3.1 Pro (High)');
       });
     });
 

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -38,8 +38,8 @@ describe('cli-builder', () => {
       expect(resolveModelAlias('claude-ultra')).toBe('opus');
     });
 
-    it('should resolve codex-ultra to gpt-5.5', () => {
-      expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.5');
+    it('should resolve codex-ultra to gpt-5.6-sol', () => {
+      expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.6-sol');
     });
 
     it('should resolve gemini-ultra to Gemini 3.1 Pro (High)', () => {
@@ -85,14 +85,31 @@ describe('cli-builder', () => {
     });
 
     it('should throw for invalid reasoning effort value', () => {
-      expect(() => getReasoningEffort('gpt-5.2', 'ultra')).toThrow(
-        'Invalid reasoning_effort: ultra. Allowed values: low, medium, high, xhigh, max.'
+      expect(() => getReasoningEffort('gpt-5.2', 'extreme')).toThrow(
+        'Invalid reasoning_effort: extreme. Allowed values: low, medium, high, xhigh, max, ultra.'
       );
     });
 
-    it('should reject max for codex models', () => {
+    it('should preserve the legacy Codex effort ceiling', () => {
       expect(() => getReasoningEffort('gpt-5.2', 'max')).toThrow(
-        'Codex reasoning_effort supports only low, medium, high, xhigh.'
+        'Codex model gpt-5.2 reasoning_effort supports only low, medium, high, xhigh.'
+      );
+      expect(() => getReasoningEffort('gpt-5.5', 'ultra')).toThrow(
+        'Codex model gpt-5.5 reasoning_effort supports only low, medium, high, xhigh.'
+      );
+    });
+
+    it('should accept low through ultra for every GPT-5.6 variant and configured Codex default', () => {
+      for (const model of ['codex', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+        for (const effort of ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']) {
+          expect(getReasoningEffort(model, effort)).toBe(effort);
+        }
+      }
+    });
+
+    it('should reject ultra for Claude', () => {
+      expect(() => getReasoningEffort('opus', 'ultra')).toThrow(
+        'Claude reasoning_effort supports only low, medium, high, xhigh, max.'
       );
     });
 
@@ -410,7 +427,7 @@ describe('cli-builder', () => {
         expect(cmd.args).toContain('model_reasoning_effort=high');
       });
 
-      it('should resolve codex-ultra and default to xhigh reasoning', () => {
+      it('should resolve codex-ultra to Sol and default to ultra reasoning', () => {
         const cmd = buildCliCommand({
           prompt: 'test',
           workFolder: '/tmp',
@@ -419,9 +436,9 @@ describe('cli-builder', () => {
         });
 
         expect(cmd.agent).toBe('codex');
-        expect(cmd.resolvedModel).toBe('gpt-5.5');
+        expect(cmd.resolvedModel).toBe('gpt-5.6-sol');
         expect(cmd.args).toContain('-c');
-        expect(cmd.args).toContain('model_reasoning_effort=xhigh');
+        expect(cmd.args).toContain('model_reasoning_effort=ultra');
       });
 
       it('should allow overriding reasoning_effort for codex-ultra', () => {
@@ -434,10 +451,29 @@ describe('cli-builder', () => {
         });
 
         expect(cmd.args).toContain('model_reasoning_effort=low');
-        expect(cmd.args).not.toContain('model_reasoning_effort=xhigh');
+        expect(cmd.args).not.toContain('model_reasoning_effort=ultra');
       });
 
-      it('should reject max reasoning_effort for codex', () => {
+      it('should build all GPT-5.6 model and effort combinations', () => {
+        for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+          for (const effort of ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']) {
+            const cmd = buildCliCommand({
+              prompt: 'test',
+              workFolder: '/tmp',
+              model,
+              reasoning_effort: effort,
+              cliPaths: DEFAULT_CLI_PATHS,
+            });
+
+            expect(cmd.agent).toBe('codex');
+            expect(cmd.resolvedModel).toBe(model);
+            expect(cmd.args).toContain(model);
+            expect(cmd.args).toContain(`model_reasoning_effort=${effort}`);
+          }
+        }
+      });
+
+      it('should reject max reasoning_effort for legacy codex', () => {
         expect(() =>
           buildCliCommand({
             prompt: 'test',
@@ -446,7 +482,7 @@ describe('cli-builder', () => {
             reasoning_effort: 'max',
             cliPaths: DEFAULT_CLI_PATHS,
           })
-        ).toThrow('Codex reasoning_effort supports only low, medium, high, xhigh.');
+        ).toThrow('Codex model gpt-5.4 reasoning_effort supports only low, medium, high, xhigh.');
       });
     });
 

--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -58,6 +58,40 @@ exit 0
   return scriptPath;
 }
 
+function createAgyOutputCliScript(dir: string, name: string): string {
+  const scriptPath = join(dir, name);
+  writeFileSync(
+    scriptPath,
+    `#!/bin/bash
+log_file=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-file)
+      log_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$log_file" ]]; then
+  mkdir -p "$(dirname "$log_file")"
+  cat > "$log_file" <<'EOF'
+I0606 server.go:753] Created conversation agy-session-123
+I0606 printmode.go:147] Print mode: conversation=agy-session-123, sending message
+EOF
+fi
+
+printf 'agy plain ok\\n'
+exit 0
+`
+  );
+  chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
 function encodeCwd(cwd: string): string {
   return cwd
     .split('')
@@ -174,7 +208,7 @@ describe('CliProcessService', () => {
     },
     {
       agent: 'gemini',
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3.5-flash',
       stdout: `
 {"type":"init","timestamp":"2026-04-18T00:00:00.000Z","session_id":"ses-fake-gemini"}
 {"type":"message","timestamp":"2026-04-18T00:00:01.000Z","role":"assistant","content":"fake gemini ok","delta":true}
@@ -255,6 +289,49 @@ fake forge ok
       agentOutput: {
         message: expectedMessage,
         session_id: expectedSessionId,
+      },
+    });
+    expect(result).not.toHaveProperty('stdout');
+    expect(result).not.toHaveProperty('stderr');
+  });
+
+  it('extracts Antigravity conversation IDs from the internal agy log', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const scriptPath = createAgyOutputCliScript(root, 'mock-agy');
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'work');
+    mkdirSync(workFolder, { recursive: true });
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: '/bin/sh',
+        codex: '/bin/sh',
+        gemini: scriptPath,
+        forge: '/bin/sh',
+        opencode: '/bin/sh',
+      },
+    });
+
+    const runResult = await service.startProcess({
+      prompt: 'hello agy',
+      cwd: workFolder,
+      model: 'gemini-3.5-flash-low',
+    });
+
+    const [result] = await service.waitForProcesses([runResult.pid], 5);
+
+    expect(result).toMatchObject({
+      pid: runResult.pid,
+      agent: 'gemini',
+      status: 'completed',
+      exitCode: 0,
+      model: 'gemini-3.5-flash-low',
+      session_id: 'agy-session-123',
+      agentOutput: {
+        message: 'agy plain ok',
+        session_id: 'agy-session-123',
       },
     });
     expect(result).not.toHaveProperty('stdout');

--- a/src/__tests__/live-cli-e2e.test.ts
+++ b/src/__tests__/live-cli-e2e.test.ts
@@ -33,7 +33,7 @@ const tempDirs: string[] = [];
 const defaultModels: Record<LiveAgent, string> = {
   claude: 'haiku',
   codex: 'gpt-5.4',
-  gemini: 'gemini-2.5-flash',
+  gemini: 'gemini-3.5-flash-high',
   forge: 'forge',
   opencode: 'opencode',
 };
@@ -224,7 +224,7 @@ if (liveEnabled) {
         expect(models.aliases).toEqual(expect.any(Array));
         expect(models.claude).toContain('haiku');
         expect(models.codex).toContain('gpt-5.4');
-        expect(models.gemini).toContain('gemini-2.5-flash');
+        expect(models.gemini).toContain('Gemini 3.5 Flash (High)');
         expect(models.forge).toEqual(['forge']);
         expect(models.opencode).toEqual(['opencode']);
       });
@@ -343,7 +343,7 @@ if (liveEnabled) {
           expect(models.aliases).toEqual(expect.any(Array));
           expect(models.claude).toContain('haiku');
           expect(models.codex).toContain('gpt-5.4');
-          expect(models.gemini).toContain('gemini-2.5-flash');
+          expect(models.gemini).toContain('Gemini 3.5 Flash (High)');
           expect(models.forge).toEqual(['forge']);
           expect(models.opencode).toEqual(['opencode']);
         });

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -116,6 +116,11 @@ describe('MCP Contract Tests', () => {
     expect(runTool.description).toContain('OpenCode');
     expect(runTool.inputSchema.properties.model.description).toContain('opencode');
     expect(runTool.inputSchema.properties.model.description).toContain('oc-<provider/model>');
+    expect(runTool.inputSchema.properties.model.description).toContain('gpt-5.6-sol');
+    expect(runTool.inputSchema.properties.reasoning_effort.enum).toBeUndefined();
+    expect(runTool.inputSchema.properties.reasoning_effort.description).toContain('GPT-5.6 Sol, Terra, Luna');
+    expect(runTool.inputSchema.properties.reasoning_effort.description).toContain('Codex CLI >= 0.144.0');
+    expect(runTool.inputSchema.properties.reasoning_effort.description).toContain('case-insensitive');
     expect(runTool.inputSchema.properties.reasoning_effort.description).toContain('OpenCode do not support reasoning_effort');
     expect(runTool.inputSchema.properties.session_id.description).toBe(
       'Optional session ID to resume a previous session. Supported for Claude, Codex, Gemini, Forge, and OpenCode. OpenCode resumes in-place via --session and may also be combined with explicit oc-<provider/model> selection.'
@@ -171,6 +176,9 @@ describe('MCP Contract Tests', () => {
     );
     expect(modelsData.claude).toContain('sonnet');
     expect(modelsData.codex).toEqual([
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
       'gpt-5.4',
       'gpt-5.5',
       'gpt-5.4-mini',
@@ -178,6 +186,16 @@ describe('MCP Contract Tests', () => {
       'gpt-5.3-codex-spark',
       'gpt-5.2',
     ]);
+    expect(modelsData.codexMinimumCliVersionForGpt56).toBe('0.144.0');
+    expect(modelsData.codexReasoningEfforts.byModel['gpt-5.6-sol']).toEqual([
+      'low', 'medium', 'high', 'xhigh', 'max', 'ultra',
+    ]);
+    expect(modelsData.codexReasoningEfforts.byModel['gpt-5.6-terra']).toEqual(
+      modelsData.codexReasoningEfforts.byModel['gpt-5.6-sol']
+    );
+    expect(modelsData.codexReasoningEfforts.byModel['gpt-5.6-luna']).toEqual(
+      modelsData.codexReasoningEfforts.byModel['gpt-5.6-sol']
+    );
     expect(modelsData.opencode).toEqual(['opencode']);
     expect(modelsData.dynamicModelBackends.opencode.explicitPattern).toBe('oc-<provider/model>');
 

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -22,7 +22,7 @@ describe('parseCodexOutput', () => {
     const output = `
 {"type":"thread.started","thread_id":"tool-test-id"}
 {"type":"turn.started"}
-{"type":"item.completed","item":{"id":"item_1","type":"mcp_tool_call","server":"acm","tool":"run","arguments":{"model":"gemini-2.5-flash","prompt":"hi"},"result":{"content":[{"text":"started","type":"text"}]},"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"mcp_tool_call","server":"acm","tool":"run","arguments":{"model":"gemini-3.5-flash","prompt":"hi"},"result":{"content":[{"text":"started","type":"text"}]},"status":"completed"}}
 {"type":"item.completed","item":{"type":"agent_message","text":"Tool executed"}}
 {"type":"turn.completed"}
 `;
@@ -34,7 +34,7 @@ describe('parseCodexOutput', () => {
     expect(result.tools[0]).toEqual({
       tool: "run",
       server: "acm",
-      input: { model: "gemini-2.5-flash", prompt: "hi" },
+      input: { model: "gemini-3.5-flash", prompt: "hi" },
       output: { content: [{ text: "started", type: "text" }] }
     });
   });
@@ -110,6 +110,20 @@ describe('PeekMessageExtractor', () => {
     expect(extractor.push(output, ts)).toEqual([
       { ts, text: 'Visible Gemini text' },
     ]);
+  });
+
+  it('extracts Antigravity plain stdout as Gemini peek messages', () => {
+    const extractor = new PeekMessageExtractor('gemini');
+
+    expect(extractor.push('Visible Antigravity text\n', ts)).toEqual([
+      { ts, text: 'Visible Antigravity text' },
+    ]);
+  });
+
+  it('does not expose Antigravity stderr logs as Gemini peek messages', () => {
+    const extractor = new PeekEventExtractor('gemini', { source: 'stderr' });
+
+    expect(extractor.push('I0606 internal agy log line\n', ts)).toEqual([]);
   });
 
   it('joins split Gemini assistant chunks into one peek message on flush', () => {
@@ -511,6 +525,31 @@ describe('PeekEventExtractor', () => {
 });
 
 describe('parseGeminiOutput', () => {
+  it('should parse Antigravity plain text output', () => {
+    expect(parseGeminiOutput('Plain Antigravity answer\n')).toEqual({
+      message: 'Plain Antigravity answer',
+    });
+  });
+
+  it('should keep Antigravity JSON-shaped answers as message text', () => {
+    expect(parseGeminiOutput('{"answer":"OK"}\n')).toEqual({
+      message: '{"answer":"OK"}',
+    });
+  });
+
+  it('should attach Antigravity conversation IDs from agy logs', () => {
+    const log = [
+      'I0606 printmode.go:82] Print mode: starting (promptLength=2, model="Gemini 3.5 Flash (Low)", conversationID="")',
+      'I0606 server.go:753] Created conversation agy-session-123',
+      'I0606 printmode.go:147] Print mode: conversation=agy-session-123, sending message',
+    ].join('\n');
+
+    expect(parseGeminiOutput('OK\n', log)).toEqual({
+      message: 'OK',
+      session_id: 'agy-session-123',
+    });
+  });
+
   it('should parse legacy final JSON output', () => {
     const output = JSON.stringify({
       session_id: 'gemini-session-json',
@@ -544,7 +583,7 @@ describe('parseGeminiOutput', () => {
 
   it('should parse Gemini stream-json NDJSON output', () => {
     const output = [
-      '{"type":"init","timestamp":"2026-04-11T14:44:42.293Z","session_id":"gemini-session-stream","model":"gemini-3.1-pro-preview"}',
+      '{"type":"init","timestamp":"2026-04-11T14:44:42.293Z","session_id":"gemini-session-stream","model":"Gemini 3.1 Pro (High)"}',
       '{"type":"message","timestamp":"2026-04-11T14:44:42.294Z","role":"user","content":"hidden user text"}',
       '{"type":"message","timestamp":"2026-04-11T14:44:53.820Z","role":"assistant","content":"First logical assistant response.","delta":true}',
       '{"type":"tool_use","timestamp":"2026-04-11T14:44:53.821Z","tool_name":"run_shell_command","tool_id":"tool-1","parameters":{"command":"echo hidden"}}',

--- a/src/__tests__/process-management.test.ts
+++ b/src/__tests__/process-management.test.ts
@@ -263,7 +263,7 @@ describe('Process Management Tests', () => {
           arguments: {
             prompt: 'gemini peek prompt',
             workFolder: '/tmp',
-            model: 'gemini-2.5-pro',
+            model: 'gemini-3.5-flash-high',
           }
         }
       });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -819,16 +819,16 @@ describe('ClaudeCodeServer Unit Tests', () => {
           arguments: {
             prompt: 'test prompt',
             workFolder: '/tmp',
-            model: 'gemini-2.5-pro',
+            model: 'gemini-3.5-flash-high',
             session_id: 'gemini-session-789'
           }
         }
       });
 
-      // Verify spawn was called with -r flag for Gemini
+      // Verify spawn was called with --conversation flag for Gemini (Antigravity CLI / agy)
       expect(mockSpawn).toHaveBeenCalledWith(
         expect.any(String),
-        expect.arrayContaining(['-r', 'gemini-session-789']),
+        expect.arrayContaining(['--conversation', 'gemini-session-789']),
         expect.any(Object)
       );
     });

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -314,7 +314,7 @@ describe('Argument Validation Tests', () => {
             arguments: {
               prompt: 'test',
               workFolder: '/tmp',
-              model: 'gemini-2.5-pro',
+              model: 'gemini-3.5-flash-high',
               reasoning_effort: 'low'
             }
           }

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -28,9 +28,9 @@ Options:
   --cwd <path>                 Working directory
   --prompt <text>              Prompt text
   --prompt-file <path>         Path to a prompt file
-  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.3-codex, codex-ultra, gemini-3.5-flash-high, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
+  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, codex-ultra, gemini-3.5-flash-high, forge, opencode, oc-openai/gpt-5.4)
   --session-id <id>            Resume a previous session, including OpenCode in-place resumes
-  --reasoning-effort <level>   Reasoning level for Claude/Codex only; unsupported for Gemini, Forge, and OpenCode
+  --reasoning-effort <level>   Claude: low..max; GPT-5.6/Codex default: low..ultra; legacy Codex: low..xhigh
   --help, -h                   Show this help message
 
 Compatibility aliases:
@@ -98,7 +98,7 @@ Options:
 
 export const MODELS_HELP_TEXT = `Usage: ai-cli models
 
-List supported models and aliases.
+List supported models, aliases, and per-model Codex reasoning capabilities.
 
 Options:
   --help, -h                   Show this help message

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -28,7 +28,7 @@ Options:
   --cwd <path>                 Working directory
   --prompt <text>              Prompt text
   --prompt-file <path>         Path to a prompt file
-  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.3-codex, codex-ultra, gemini-2.5-pro, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
+  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.3-codex, codex-ultra, gemini-3.5-flash-high, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
   --session-id <id>            Resume a previous session, including OpenCode in-place resumes
   --reasoning-effort <level>   Reasoning level for Claude/Codex only; unsupported for Gemini, Forge, and OpenCode
   --help, -h                   Show this help message

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -88,7 +88,7 @@ export class ClaudeCodeServer {
     this.opencodeCliPath = this.resolveDoctorCliPath(doctorStatus.opencode);
     console.error(`[Setup] Using Claude CLI command/path: ${this.claudeCliPath}`);
     console.error(`[Setup] Using Codex CLI command/path: ${this.codexCliPath}`);
-    console.error(`[Setup] Using Gemini CLI command/path: ${this.geminiCliPath}`);
+    console.error(`[Setup] Using Gemini/Antigravity CLI command/path: ${this.geminiCliPath}`);
     console.error(`[Setup] Using Forge CLI command/path: ${this.forgeCliPath}`);
     console.error(`[Setup] Using OpenCode CLI command/path: ${this.opencodeCliPath}`);
     this.processService = new ProcessService({

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -10,7 +10,12 @@ import {
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { debugLog, getCliDoctorStatus, type CliBinaryStatus } from '../cli-utils.js';
-import { getModelParameterDescription, getModelsPayload, getSupportedModelsDescription } from '../model-catalog.js';
+import {
+  getModelParameterDescription,
+  getModelsPayload,
+  getReasoningEffortParameterDescription,
+  getSupportedModelsDescription,
+} from '../model-catalog.js';
 import { validatePeekPids, validatePeekTimeSec } from '../peek.js';
 import { ProcessService } from '../process-service.js';
 
@@ -186,7 +191,7 @@ ${getSupportedModelsDescription()}
               },
               reasoning_effort: {
                 type: 'string',
-                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high", "xhigh", "max". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh". Gemini, Forge, and OpenCode do not support reasoning_effort in this integration.',
+                description: getReasoningEffortParameterDescription(),
               },
               session_id: {
                 type: 'string',
@@ -300,7 +305,7 @@ ${getSupportedModelsDescription()}
         },
         {
           name: 'models',
-          description: 'List supported model names, model aliases, and dynamic backend discovery hints.',
+          description: 'List supported model names, model aliases, per-model Codex reasoning capabilities, and dynamic backend discovery hints.',
           inputSchema: {
             type: 'object',
             properties: {},

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -1,11 +1,17 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve as pathResolve, isAbsolute } from 'node:path';
 import type { CliPaths } from './cli-utils.js';
-import { MODEL_ALIASES } from './model-catalog.js';
+import {
+  CODEX_REASONING_EFFORTS_BY_MODEL,
+  LEGACY_CODEX_REASONING_EFFORTS,
+  MODEL_ALIASES,
+  MODEL_ALIAS_DEFAULT_REASONING_EFFORTS,
+  REASONING_EFFORT_LEVELS,
+} from './model-catalog.js';
 
-export const ALLOWED_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+export const ALLOWED_REASONING_EFFORTS = new Set<string>(REASONING_EFFORT_LEVELS);
 const CLAUDE_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
-const CODEX_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
+const LEGACY_CODEX_REASONING_EFFORT_SET = new Set<string>(LEGACY_CODEX_REASONING_EFFORTS);
 const OPENCODE_MODEL_ERROR = 'Invalid OpenCode model. Expected exact syntax oc-<provider/model>.';
 
 type Agent = 'codex' | 'claude' | 'gemini' | 'forge' | 'opencode';
@@ -106,7 +112,7 @@ export function getReasoningEffort(model: string, rawValue: unknown): string {
   const normalized = trimmed.toLowerCase();
   if (!ALLOWED_REASONING_EFFORTS.has(normalized)) {
     throw new Error(
-      `Invalid reasoning_effort: ${rawValue}. Allowed values: low, medium, high, xhigh, max.`
+      `Invalid reasoning_effort: ${rawValue}. Allowed values: ${REASONING_EFFORT_LEVELS.join(', ')}.`
     );
   }
   const agent = getStandardAgentForModel(model);
@@ -123,9 +129,16 @@ export function getReasoningEffort(model: string, rawValue: unknown): string {
       'Claude reasoning_effort supports only low, medium, high, xhigh, max.'
     );
   }
-  if (agent === 'codex' && !CODEX_REASONING_EFFORTS.has(normalized)) {
+  const codexEfforts = agent === 'codex'
+    ? new Set<string>(
+      CODEX_REASONING_EFFORTS_BY_MODEL[
+        model as keyof typeof CODEX_REASONING_EFFORTS_BY_MODEL
+      ] || LEGACY_CODEX_REASONING_EFFORTS
+    )
+    : LEGACY_CODEX_REASONING_EFFORT_SET;
+  if (agent === 'codex' && !codexEfforts.has(normalized)) {
     throw new Error(
-      'Codex reasoning_effort supports only low, medium, high, xhigh.'
+      `Codex model ${model || '(default)'} reasoning_effort supports only ${[...codexEfforts].join(', ')}.`
     );
   }
   return normalized;
@@ -196,11 +209,7 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
 
   let reasoningEffortArg: string | undefined = options.reasoning_effort;
   if (!reasoningEffortArg) {
-    if (rawModel === 'codex-ultra') {
-      reasoningEffortArg = 'xhigh';
-    } else if (rawModel === 'claude-ultra') {
-      reasoningEffortArg = 'max';
-    }
+    reasoningEffortArg = MODEL_ALIAS_DEFAULT_REASONING_EFFORTS[rawModel];
   }
 
   const reasoningTargetModel = rawModel === 'opencode' || rawModel.startsWith('oc-')

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -26,7 +26,8 @@ function getStandardAgentForModel(model: string): Exclude<Agent, 'opencode'> {
   if (model.startsWith('gpt-')) {
     return 'codex';
   }
-  if (model.startsWith('gemini')) {
+  // Case-insensitive: o agy (Antigravity CLI) usa nomes como "Gemini 3.5 Flash (High)".
+  if (model.toLowerCase().startsWith('gemini')) {
     return 'gemini';
   }
   return 'claude';
@@ -146,6 +147,7 @@ export interface BuildCliCommandOptions {
   model?: string;
   session_id?: string;
   reasoning_effort?: string;
+  log_file?: string;
   cliPaths: CliPaths;
 }
 
@@ -227,18 +229,26 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
 
     args.push('--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', '--json', prompt);
   } else if (agent === 'gemini') {
+    // Servido pelo Antigravity CLI (agy) via wrapper agy-mcp. Modo "yolo" headless:
+    // -p (print/one-shot), --dangerously-skip-permissions (auto-aprova tools),
+    // --model "<nome>" (ex.: "Gemini 3.5 Flash (High)"), resume via --conversation.
+    // O agy NÃO suporta -y nem --output-format stream-json (saída é texto puro).
     cliPath = options.cliPaths.gemini;
-    args = ['-y', '--output-format', 'stream-json'];
+    args = ['--dangerously-skip-permissions'];
+
+    if (options.log_file && typeof options.log_file === 'string' && options.log_file.trim()) {
+      args.push('--log-file', options.log_file);
+    }
 
     if (options.session_id && typeof options.session_id === 'string') {
-      args.push('-r', options.session_id);
+      args.push('--conversation', options.session_id);
     }
 
     if (resolvedModel) {
       args.push('--model', resolvedModel);
     }
 
-    args.push(prompt);
+    args.push('-p', prompt);
   } else if (agent === 'forge') {
     cliPath = options.cliPaths.forge;
     args = ['-C', cwd];

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import {
   appendFileSync,
   chmodSync,
@@ -42,6 +43,7 @@ interface StoredProcess {
   startTime: string;
   stdoutPath: string;
   stderrPath: string;
+  logPath?: string;
   status: 'running' | 'completed' | 'failed';
   exitCode?: number;
 }
@@ -90,9 +92,13 @@ function normalizeCwdForStorage(cwd: string): string {
     .join('');
 }
 
-function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any {
+function parseAgentOutput(agent: AgentType, stdout: string, stderr: string, logText = ''): any {
   if (agent === 'codex') {
     return parseCodexOutput(`${stdout}\n${stderr}`);
+  }
+
+  if (agent === 'gemini') {
+    return parseGeminiOutput(stdout, logText);
   }
 
   if (!stdout) {
@@ -101,9 +107,6 @@ function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any
 
   if (agent === 'claude') {
     return parseClaudeOutput(stdout);
-  }
-  if (agent === 'gemini') {
-    return parseGeminiOutput(stdout);
   }
   if (agent === 'forge') {
     return parseForgeOutput(stdout);
@@ -131,7 +134,7 @@ export class CliProcessService {
   }
 
   async startProcess(options: CliRunOptions): Promise<{ pid: number; status: 'started'; agent: AgentType; message: string }> {
-    const cmd = buildCliCommand({
+    let cmd = buildCliCommand({
       prompt: options.prompt,
       prompt_file: options.prompt_file,
       workFolder: options.cwd,
@@ -141,7 +144,22 @@ export class CliProcessService {
       cliPaths: this.cliPaths,
     });
 
-    return this.startDetachedTrackedProcess(cmd, options.model);
+    let logPath: string | undefined;
+    if (cmd.agent === 'gemini') {
+      logPath = this.createAgyLogPath();
+      cmd = buildCliCommand({
+        prompt: options.prompt,
+        prompt_file: options.prompt_file,
+        workFolder: options.cwd,
+        model: options.model,
+        session_id: options.session_id,
+        reasoning_effort: options.reasoning_effort,
+        log_file: logPath,
+        cliPaths: this.cliPaths,
+      });
+    }
+
+    return this.startDetachedTrackedProcess(cmd, options.model, logPath);
   }
 
   async listProcesses(): Promise<ProcessListItem[]> {
@@ -157,7 +175,8 @@ export class CliProcessService {
     const refreshed = this.refreshStatus(storedProcess);
     const stdout = this.readTextFileSafe(refreshed.stdoutPath);
     const stderr = this.readTextFileSafe(refreshed.stderrPath);
-    const agentOutput = parseAgentOutput(refreshed.toolType, stdout, stderr);
+    const logText = refreshed.logPath ? this.readTextFileSafe(refreshed.logPath) : '';
+    const agentOutput = parseAgentOutput(refreshed.toolType, stdout, stderr, logText);
 
     return buildProcessResult({
       pid,
@@ -336,6 +355,9 @@ export class CliProcessService {
       }
 
       const processDir = this.resolveStoredProcessDir(refreshed);
+      if (refreshed.logPath && existsSync(refreshed.logPath)) {
+        rmSync(refreshed.logPath, { force: true });
+      }
       if (existsSync(processDir)) {
         rmSync(processDir, { recursive: true, force: true });
         removed++;
@@ -353,6 +375,7 @@ export class CliProcessService {
   private async startDetachedTrackedProcess(
     cmd: Awaited<ReturnType<typeof buildCliCommand>>,
     model: string | undefined,
+    logPath: string | undefined,
   ): Promise<{ pid: number; status: 'started'; agent: AgentType; message: string }> {
     const cwdKey = this.resolveCwdKey(cmd.cwd);
     const wrapperPath = this.ensureDetachedWrapperScript();
@@ -387,6 +410,7 @@ export class CliProcessService {
       startTime: new Date().toISOString(),
       stdoutPath,
       stderrPath,
+      logPath,
       status: 'running',
     };
     this.writeProcess(storedProcess);
@@ -506,6 +530,12 @@ export class CliProcessService {
       appendFileSync(filePath, text);
     } catch {
     }
+  }
+
+  private createAgyLogPath(): string {
+    const logDir = join(this.stateDir, 'logs');
+    mkdirSync(logDir, { recursive: true });
+    return join(logDir, `${randomUUID()}.agy.log`);
   }
 
   private fileSizeSafe(filePath: string): number {

--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -214,8 +214,11 @@ function getCliBinaryConfig(name: CliBinaryName): {
   return {
     envVarName: 'GEMINI_CLI_NAME',
     customCliName: process.env.GEMINI_CLI_NAME,
-    defaultCliName: 'gemini',
-    localInstallPath: join(homedir(), '.gemini', 'local', 'gemini'),
+    // O agente "gemini" agora é servido pelo Antigravity CLI (agy), via o wrapper
+    // agy-mcp (remove envs SSH p/ o agy usar o keyring da subscrição). O gemini-cli
+    // foi descontinuado neste ambiente. Override por GEMINI_CLI_NAME se necessário.
+    defaultCliName: 'agy-mcp',
+    localInstallPath: join(homedir(), '.local', 'bin', 'agy-mcp'),
   };
 }
 
@@ -240,7 +243,7 @@ export function getCliDoctorStatus(): CliDoctorStatus {
 }
 
 export function findGeminiCli(): string {
-  debugLog('[Debug] Attempting to find Gemini CLI...');
+  debugLog('[Debug] Attempting to find Gemini/Antigravity CLI...');
   const status = getCliBinaryStatus('gemini');
   return getCliCommandOrThrow(status);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,12 +35,12 @@ function parseArgs(argv: string[]): Record<string, string> {
 const USAGE = `Usage: npm run -s cli.run -- --model <model> --workFolder <path> --prompt "..." [options]
 
 Options:
-  --model              Model name or alias (e.g. sonnet, opus, gpt-5.3-codex, gemini-3.5-flash-high, forge, opencode, oc-openai/gpt-5.4)
+  --model              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, codex-ultra, gemini-3.5-flash-high, forge, opencode, oc-openai/gpt-5.4)
   --workFolder         Working directory (absolute path)
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt
   --session_id         Session ID to resume, including OpenCode in-place resumes
-  --reasoning_effort   Claude/Codex only: Claude=low|medium|high|xhigh|max, Codex=low|medium|high|xhigh; unsupported for Gemini, Forge, and OpenCode
+  --reasoning_effort   Claude=low..max; GPT-5.6/Codex default=low..ultra; legacy Codex=low..xhigh
   --help               Show this help message
 
 Raw CLI output goes to stdout. Use cli.run.parse to parse the output:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ function parseArgs(argv: string[]): Record<string, string> {
 const USAGE = `Usage: npm run -s cli.run -- --model <model> --workFolder <path> --prompt "..." [options]
 
 Options:
-  --model              Model name or alias (e.g. sonnet, opus, gpt-5.3-codex, gemini-2.5-pro, forge, opencode, oc-openai/gpt-5.4)
+  --model              Model name or alias (e.g. sonnet, opus, gpt-5.3-codex, gemini-3.5-flash-high, forge, opencode, oc-openai/gpt-5.4)
   --workFolder         Working directory (absolute path)
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,5 +1,8 @@
 export const CLAUDE_MODELS = ['sonnet', 'sonnet[1m]', 'opus', 'opusplan', 'haiku'] as const;
 export const CODEX_MODELS = [
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   'gpt-5.4',
   'gpt-5.5',
   'gpt-5.4-mini',
@@ -20,9 +23,23 @@ export const GEMINI_MODELS = [
 export const FORGE_MODELS = ['forge'] as const;
 export const OPENCODE_MODELS = ['opencode'] as const;
 
+export const REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
+export const LEGACY_CODEX_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
+export const GPT_5_6_MINIMUM_CODEX_CLI_VERSION = '0.144.0';
+
+// Codex CLI 0.144.0 accepts all six levels for the three GPT-5.6 variants.
+// Luna's UI catalog currently omits ultra, but the backend accepted and
+// reported gpt-5.6-luna + ultra in a live turn-context check on 2026-07-09.
+export const CODEX_REASONING_EFFORTS_BY_MODEL = {
+  codex: REASONING_EFFORT_LEVELS,
+  'gpt-5.6-sol': REASONING_EFFORT_LEVELS,
+  'gpt-5.6-terra': REASONING_EFFORT_LEVELS,
+  'gpt-5.6-luna': REASONING_EFFORT_LEVELS,
+} as const;
+
 export const MODEL_ALIASES: Record<string, string> = {
   'claude-ultra': 'opus',
-  'codex-ultra': 'gpt-5.5',
+  'codex-ultra': 'gpt-5.6-sol',
   // Aliases lowercase -> nome de exibição aceito pelo agy.
   'gemini-ultra': 'Gemini 3.1 Pro (High)',
   'gemini-3.5-flash-high': 'Gemini 3.5 Flash (High)',
@@ -34,7 +51,7 @@ export const MODEL_ALIASES: Record<string, string> = {
 
 export const MODEL_ALIAS_DETAILS = [
   { name: 'claude-ultra', resolvesTo: 'opus', agent: 'claude', defaultReasoningEffort: 'max' },
-  { name: 'codex-ultra', resolvesTo: 'gpt-5.5', agent: 'codex', defaultReasoningEffort: 'xhigh' },
+  { name: 'codex-ultra', resolvesTo: 'gpt-5.6-sol', agent: 'codex', defaultReasoningEffort: 'ultra' },
   { name: 'gemini-ultra', resolvesTo: 'Gemini 3.1 Pro (High)', agent: 'gemini' },
   { name: 'gemini-3.5-flash-high', resolvesTo: 'Gemini 3.5 Flash (High)', agent: 'gemini' },
   { name: 'gemini-3.5-flash', resolvesTo: 'Gemini 3.5 Flash (Medium)', agent: 'gemini' },
@@ -42,6 +59,14 @@ export const MODEL_ALIAS_DETAILS = [
   { name: 'gemini-3.1-pro', resolvesTo: 'Gemini 3.1 Pro (High)', agent: 'gemini' },
   { name: 'gemini-3.1-pro-low', resolvesTo: 'Gemini 3.1 Pro (Low)', agent: 'gemini' },
 ] as const;
+
+export const MODEL_ALIAS_DEFAULT_REASONING_EFFORTS: Readonly<Record<string, string>> =
+  MODEL_ALIAS_DETAILS.reduce<Record<string, string>>((defaults, alias) => {
+    if ('defaultReasoningEffort' in alias) {
+      defaults[alias.name] = alias.defaultReasoningEffort;
+    }
+    return defaults;
+  }, {});
 
 export interface DynamicModelBackendDescription {
   explicitPrefix: string;
@@ -63,13 +88,22 @@ export function getSupportedModelsDescription(): string {
 }
 
 export function getModelParameterDescription(): string {
-  return `The model to use. Aliases: "claude-ultra" (auto max effort), "codex-ultra" (auto xhigh reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...GEMINI_MODELS, ...FORGE_MODELS, ...OPENCODE_MODELS].map((model) => `"${model}"`).join(', ')}. OpenCode also accepts explicit dynamic models using "oc-<provider/model>". "forge" is a provider key, not a Forge model family selector.`;
+  return `The model to use. Aliases: "claude-ultra" (auto max effort), "codex-ultra" (gpt-5.6-sol with auto ultra reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...GEMINI_MODELS, ...FORGE_MODELS, ...OPENCODE_MODELS].map((model) => `"${model}"`).join(', ')}. OpenCode also accepts explicit dynamic models using "oc-<provider/model>". "forge" is a provider key, not a Forge model family selector.`;
+}
+
+export function getReasoningEffortParameterDescription(): string {
+  return `Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high", "xhigh", or "max". GPT-5.6 Sol, Terra, Luna, and the configured Codex default use model_reasoning_effort with "low", "medium", "high", "xhigh", "max", or "ultra" and require Codex CLI >= ${GPT_5_6_MINIMUM_CODEX_CLI_VERSION}; legacy explicit Codex models remain limited to "low" through "xhigh". Values are case-insensitive and trimmed. Gemini, Forge, and OpenCode do not support reasoning_effort in this integration.`;
 }
 
 export function getModelsPayload(): {
   aliases: ReadonlyArray<(typeof MODEL_ALIAS_DETAILS)[number]>;
   claude: ReadonlyArray<string>;
   codex: ReadonlyArray<string>;
+  codexMinimumCliVersionForGpt56: string;
+  codexReasoningEfforts: {
+    legacyDefault: ReadonlyArray<string>;
+    byModel: typeof CODEX_REASONING_EFFORTS_BY_MODEL;
+  };
   gemini: ReadonlyArray<string>;
   forge: ReadonlyArray<string>;
   opencode: ReadonlyArray<string>;
@@ -81,6 +115,11 @@ export function getModelsPayload(): {
     aliases: MODEL_ALIAS_DETAILS,
     claude: CLAUDE_MODELS,
     codex: CODEX_MODELS,
+    codexMinimumCliVersionForGpt56: GPT_5_6_MINIMUM_CODEX_CLI_VERSION,
+    codexReasoningEfforts: {
+      legacyDefault: LEGACY_CODEX_REASONING_EFFORTS,
+      byModel: CODEX_REASONING_EFFORTS_BY_MODEL,
+    },
     gemini: GEMINI_MODELS,
     forge: FORGE_MODELS,
     opencode: OPENCODE_MODELS,

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -7,12 +7,15 @@ export const CODEX_MODELS = [
   'gpt-5.3-codex-spark',
   'gpt-5.2',
 ] as const;
+// Modelos do agente "gemini" servidos pelo Antigravity CLI (agy). O nome de
+// exibição (com o nível de raciocínio entre parênteses) É o ID aceito pelo
+// --model. Use os aliases lowercase abaixo para conveniência.
 export const GEMINI_MODELS = [
-  'gemini-2.5-pro',
-  'gemini-2.5-flash',
-  'gemini-3.1-pro-preview',
-  'gemini-3-pro-preview',
-  'gemini-3-flash-preview',
+  'Gemini 3.5 Flash (High)',
+  'Gemini 3.5 Flash (Medium)',
+  'Gemini 3.5 Flash (Low)',
+  'Gemini 3.1 Pro (High)',
+  'Gemini 3.1 Pro (Low)',
 ] as const;
 export const FORGE_MODELS = ['forge'] as const;
 export const OPENCODE_MODELS = ['opencode'] as const;
@@ -20,13 +23,24 @@ export const OPENCODE_MODELS = ['opencode'] as const;
 export const MODEL_ALIASES: Record<string, string> = {
   'claude-ultra': 'opus',
   'codex-ultra': 'gpt-5.5',
-  'gemini-ultra': 'gemini-3.1-pro-preview',
+  // Aliases lowercase -> nome de exibição aceito pelo agy.
+  'gemini-ultra': 'Gemini 3.1 Pro (High)',
+  'gemini-3.5-flash-high': 'Gemini 3.5 Flash (High)',
+  'gemini-3.5-flash': 'Gemini 3.5 Flash (Medium)',
+  'gemini-3.5-flash-low': 'Gemini 3.5 Flash (Low)',
+  'gemini-3.1-pro': 'Gemini 3.1 Pro (High)',
+  'gemini-3.1-pro-low': 'Gemini 3.1 Pro (Low)',
 };
 
 export const MODEL_ALIAS_DETAILS = [
   { name: 'claude-ultra', resolvesTo: 'opus', agent: 'claude', defaultReasoningEffort: 'max' },
   { name: 'codex-ultra', resolvesTo: 'gpt-5.5', agent: 'codex', defaultReasoningEffort: 'xhigh' },
-  { name: 'gemini-ultra', resolvesTo: 'gemini-3.1-pro-preview', agent: 'gemini' },
+  { name: 'gemini-ultra', resolvesTo: 'Gemini 3.1 Pro (High)', agent: 'gemini' },
+  { name: 'gemini-3.5-flash-high', resolvesTo: 'Gemini 3.5 Flash (High)', agent: 'gemini' },
+  { name: 'gemini-3.5-flash', resolvesTo: 'Gemini 3.5 Flash (Medium)', agent: 'gemini' },
+  { name: 'gemini-3.5-flash-low', resolvesTo: 'Gemini 3.5 Flash (Low)', agent: 'gemini' },
+  { name: 'gemini-3.1-pro', resolvesTo: 'Gemini 3.1 Pro (High)', agent: 'gemini' },
+  { name: 'gemini-3.1-pro-low', resolvesTo: 'Gemini 3.1 Pro (Low)', agent: 'gemini' },
 ] as const;
 
 export interface DynamicModelBackendDescription {

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -78,6 +78,62 @@ function isGeminiStreamJsonEvent(parsed: any): boolean {
   return parsed && typeof parsed === 'object' && !Array.isArray(parsed) && GEMINI_STREAM_EVENT_TYPES.has(parsed.type);
 }
 
+function isPlainObject(value: any): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isGeminiLegacyFinalOutput(parsed: any): boolean {
+  if (!isPlainObject(parsed)) {
+    return false;
+  }
+
+  return (
+    typeof parsed.session_id === 'string' ||
+    (isPlainObject(parsed.stats) && (typeof parsed.response === 'string' || typeof parsed.message === 'string'))
+  );
+}
+
+function parseAgyConversationId(logText: string): string | null {
+  let conversationId: string | null = null;
+
+  for (const line of logText.split(/\r?\n/)) {
+    const createdMatch = line.match(/\bCreated conversation ([A-Za-z0-9._:-]+)/);
+    if (createdMatch?.[1]) {
+      conversationId = createdMatch[1];
+      continue;
+    }
+
+    const printModeMatch = line.match(/\bPrint mode: conversation=([A-Za-z0-9._:-]+)/);
+    if (printModeMatch?.[1]) {
+      conversationId = printModeMatch[1];
+      continue;
+    }
+
+    const startingMatch = line.match(/\bconversationID="([^"]+)"/);
+    if (startingMatch?.[1]) {
+      conversationId = startingMatch[1];
+    }
+  }
+
+  return conversationId;
+}
+
+function attachGeminiLogSession<T>(output: T, logText: string): T {
+  if (!isPlainObject(output) || output.session_id) {
+    return output;
+  }
+
+  const conversationId = parseAgyConversationId(logText);
+  if (!conversationId) {
+    return output;
+  }
+
+  return {
+    ...output,
+    session_id: conversationId,
+  };
+}
+
 function oneLine(value: unknown): string {
   return String(value ?? '').replace(/\s+/g, ' ').trim();
 }
@@ -419,6 +475,9 @@ export class PeekEventExtractor {
       } catch {
         debugLog(`[Debug] Skipping invalid peek JSON line: ${line}`);
         events.push(...this.flushGeminiAssistantBuffer(observedAt));
+        if (this.agent === 'gemini' && this.source === 'stdout') {
+          events.push({ kind: 'message', ts: observedAt, text: line });
+        }
       }
     }
 
@@ -739,13 +798,18 @@ export function parseClaudeOutput(stdout: string): any {
   return null;
 }
 
-export function parseGeminiOutput(stdout: string): any {
-  if (!stdout) return null;
+export function parseGeminiOutput(stdout: string, agyLogText = ''): any {
+  if (!stdout) {
+    const conversationId = parseAgyConversationId(agyLogText);
+    return conversationId ? { session_id: conversationId } : null;
+  }
 
   try {
     const parsed = JSON.parse(stdout.trim());
     if (!isGeminiStreamJsonEvent(parsed)) {
-      return parsed;
+      if (isGeminiLegacyFinalOutput(parsed)) {
+        return attachGeminiLogSession(parsed, agyLogText);
+      }
     }
   } catch (e) {
     debugLog(`[Debug] Failed to parse Gemini JSON output: ${e}`);
@@ -831,11 +895,19 @@ export function parseGeminiOutput(stdout: string): any {
 
   flushAssistantMessage();
   const tools = [...toolsById.values(), ...toolsWithoutId];
+  const logSessionId = sessionId || parseAgyConversationId(agyLogText);
 
-  if (lastMessage || sessionId || stats || tools.length > 0) {
+  // Antigravity CLI (agy) em modo -p emite TEXTO PURO (sem stream-json). Quando
+  // nenhum evento estruturado foi reconhecido, devolve a saída como a mensagem.
+  const plainText = stdout.trim();
+  if (!lastMessage && !stats && tools.length === 0 && plainText) {
+    return logSessionId ? { message: plainText, session_id: logSessionId } : { message: plainText };
+  }
+
+  if (lastMessage || logSessionId || stats || tools.length > 0) {
     return {
       message: lastMessage,
-      session_id: sessionId,
+      session_id: logSessionId,
       stats: stats || undefined,
       tools: tools.length > 0 ? tools : undefined,
     };

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,4 +1,8 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import {
@@ -25,6 +29,7 @@ interface TrackedProcess {
   startTime: string;
   stdout: string;
   stderr: string;
+  logPath?: string;
   status: ProcessStatus;
   exitCode?: number;
 }
@@ -46,9 +51,13 @@ interface ProcessServiceOptions {
   cliPaths: BuildCliCommandOptions['cliPaths'];
 }
 
-function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any {
+function parseAgentOutput(agent: AgentType, stdout: string, stderr: string, logText = ''): any {
   if (agent === 'codex') {
     return parseCodexOutput(`${stdout || ''}\n${stderr || ''}`);
+  }
+
+  if (agent === 'gemini') {
+    return parseGeminiOutput(stdout, logText);
   }
 
   if (!stdout) {
@@ -57,9 +66,6 @@ function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any
 
   if (agent === 'claude') {
     return parseClaudeOutput(stdout);
-  }
-  if (agent === 'gemini') {
-    return parseGeminiOutput(stdout);
   }
   if (agent === 'forge') {
     return parseForgeOutput(stdout);
@@ -80,10 +86,20 @@ export class ProcessService {
   }
 
   startProcess(options: Omit<BuildCliCommandOptions, 'cliPaths'>): StartProcessResult {
-    const cmd = buildCliCommand({
+    let cmd = buildCliCommand({
       ...options,
       cliPaths: this.cliPaths,
     });
+
+    let logPath: string | undefined;
+    if (cmd.agent === 'gemini') {
+      logPath = this.createAgyLogPath();
+      cmd = buildCliCommand({
+        ...options,
+        log_file: logPath,
+        cliPaths: this.cliPaths,
+      });
+    }
 
     const { cliPath, args: processArgs, cwd: effectiveCwd, agent, prompt } = cmd;
     const childProcess = spawn(cliPath, processArgs, {
@@ -107,6 +123,7 @@ export class ProcessService {
       startTime: new Date().toISOString(),
       stdout: '',
       stderr: '',
+      logPath,
       status: 'running',
     };
 
@@ -170,7 +187,8 @@ export class ProcessService {
       throw new Error(`Process with PID ${pid} not found`);
     }
 
-    const agentOutput = parseAgentOutput(process.toolType, process.stdout, process.stderr);
+    const logText = process.logPath ? this.readTextFileSafe(process.logPath) : '';
+    const agentOutput = parseAgentOutput(process.toolType, process.stdout, process.stderr, logText);
 
     return buildProcessResult({
       pid,
@@ -355,6 +373,9 @@ export class ProcessService {
     for (const [pid, process] of this.processManager.entries()) {
       if (process.status === 'completed' || process.status === 'failed') {
         removedPids.push(pid);
+        if (process.logPath) {
+          this.removeAgyLogPath(process.logPath);
+        }
         this.processManager.delete(pid);
       }
     }
@@ -364,5 +385,29 @@ export class ProcessService {
       removedPids,
       message: `Cleaned up ${removedPids.length} finished process(es)`,
     };
+  }
+
+  private createAgyLogPath(): string {
+    return join(tmpdir() || '.', `ai-cli-mcp-agy-${randomUUID()}.log`);
+  }
+
+  private readTextFileSafe(filePath: string): string {
+    if (!existsSync(filePath)) {
+      return '';
+    }
+
+    try {
+      const text = readFileSync(filePath, 'utf-8');
+      return typeof text === 'string' ? text : '';
+    } catch {
+      return '';
+    }
+  }
+
+  private removeAgyLogPath(filePath: string): void {
+    try {
+      rmSync(filePath, { force: true });
+    } catch {
+    }
   }
 }


### PR DESCRIPTION
## Summary

- route the Gemini agent through Antigravity CLI (`agy-mcp`) while preserving process/session parsing
- add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
- support `low`, `medium`, `high`, `xhigh`, `max`, and `ultra` for GPT-5.6 and the configured Codex default
- move `codex-ultra` from GPT-5.5/xhigh to GPT-5.6-Sol/ultra, with an explicit migration note
- expose per-model reasoning capabilities and the minimum Codex CLI version from `ai-cli models`
- retain the legacy Codex ceiling through `xhigh`

## Compatibility

- GPT-5.6 requires Codex CLI >= 0.144.0
- callers that require the old alias behavior can pin `gpt-5.5` + `xhigh`
- MCP schema remains permissive so existing uppercase/whitespace effort inputs still reach runtime normalization
- Antigravity coverage remains part of the full regression suite

## Validation

- `npm test`: 297 passed, 2 skipped
- `npm run test:package`: 4 passed
- commit hook `npm run test:unit`: 274 passed
- deterministic argv smoke: all 18 GPT-5.6 model/effort combinations plus `codex-ultra`
- `git diff --check` clean