### PR TITLE
fix: support Windows CLI process execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,23 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [20.19.0, 22.12.0, 24.x]
+        include:
+          - os: ubuntu-latest
+            node-version: 20.19.0
+          - os: ubuntu-latest
+            node-version: 22.12.0
+          - os: ubuntu-latest
+            node-version: 24.x
+          - os: windows-latest
+            node-version: 22.12.0
+          - os: macos-latest
+            node-version: 22.12.0
 
     steps:
     - name: Checkout repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "cross-spawn": "^7.0.6",
         "zod": "^3.24.4"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "dist/cli-process-service.js",
     "dist/cli-utils.js",
     "dist/cli.js",
+    "dist/detached-runner.cjs",
     "dist/model-catalog.js",
     "dist/parsers.js",
     "dist/peek.js",
     "dist/process-result.js",
     "dist/process-service.js",
     "dist/server.js",
+    "dist/spawn-cli.js",
     "server.json",
     "README.ja.md",
     "CHANGELOG.md"
@@ -50,6 +52,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "cross-spawn": "^7.0.6",
     "zod": "^3.24.4"
   },
   "engines": {

--- a/src/__tests__/cli-bin-smoke.test.ts
+++ b/src/__tests__/cli-bin-smoke.test.ts
@@ -13,9 +13,14 @@ function makeTempDir(prefix: string): string {
 }
 
 function writeExecutable(dir: string, name: string): void {
-  const filePath = join(dir, name);
-  writeFileSync(filePath, '#!/bin/sh\nexit 0\n', 'utf8');
-  chmodSync(filePath, 0o755);
+  const filePath = join(dir, process.platform === 'win32' ? `${name}.cmd` : name);
+  const script = process.platform === 'win32'
+    ? '@ECHO off\r\nexit /b 0\r\n'
+    : '#!/bin/sh\nexit 0\n';
+  writeFileSync(filePath, script, 'utf8');
+  if (process.platform !== 'win32') {
+    chmodSync(filePath, 0o755);
+  }
 }
 
 afterEach(() => {

--- a/src/__tests__/cli-process-service-node-runner.test.ts
+++ b/src/__tests__/cli-process-service-node-runner.test.ts
@@ -1,0 +1,160 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CliProcessService } from '../cli-process-service.js';
+
+const tempDirs: string[] = [];
+
+function encodeCwd(cwd: string): string {
+  return cwd
+    .split('')
+    .map((char) => (/^[A-Za-z0-9.-]$/.test(char) ? char : `_${char.charCodeAt(0).toString(16).padStart(2, '0')}`))
+    .join('');
+}
+
+function createServiceFixture(): {
+  service: CliProcessService;
+  stateDir: string;
+  workFolder: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'ai-cli-node-service-'));
+  tempDirs.push(root);
+  const stateDir = join(root, 'state');
+  const workFolder = join(root, 'work');
+  mkdirSync(workFolder, { recursive: true });
+  return {
+    service: new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: process.execPath,
+        codex: process.execPath,
+        gemini: process.execPath,
+        forge: process.execPath,
+        opencode: process.execPath,
+      },
+    }),
+    stateDir,
+    workFolder,
+  };
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 50; attempt++) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+        lastError = undefined;
+        break;
+      } catch (error: any) {
+        lastError = error;
+        if (!['EBUSY', 'ENOTEMPTY', 'EPERM'].includes(error.code)) {
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+    if (lastError) {
+      throw lastError;
+    }
+  }
+});
+
+describe('CliProcessService with the detached Node.js runner', () => {
+  it('runs a native executable and persists its output without a shell wrapper', async () => {
+    const { service, stateDir, workFolder } = createServiceFixture();
+    const started = await service.startProcess({
+      cwd: workFolder,
+      model: 'forge',
+      prompt: '40 + 2',
+    });
+
+    const [result] = await service.waitForProcesses([started.pid], 5);
+    const processDir = join(
+      stateDir,
+      'cwds',
+      encodeCwd(realpathSync(workFolder)),
+      String(started.pid),
+    );
+
+    expect(result).toMatchObject({
+      pid: started.pid,
+      agent: 'forge',
+      status: 'completed',
+      exitCode: 0,
+    });
+    expect(readFileSync(join(processDir, 'stdout.log'), 'utf8')).toContain('42');
+    expect(JSON.parse(readFileSync(join(processDir, 'exit-status.json'), 'utf8'))).toEqual({
+      status: 'completed',
+      exitCode: 0,
+    });
+    expect(existsSync(join(stateDir, 'detached-runner-v2.sh'))).toBe(false);
+  });
+
+  it('terminates the detached runner process tree and records a failed exit', async () => {
+    const { service, workFolder } = createServiceFixture();
+    const started = await service.startProcess({
+      cwd: workFolder,
+      model: 'forge',
+      prompt: 'setInterval(() => {}, 1000)',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const killed = await service.killProcess(started.pid);
+    const result = await service.getProcessResult(started.pid);
+
+    expect(killed).toEqual({
+      pid: started.pid,
+      status: 'terminated',
+      message: 'Process terminated successfully',
+    });
+    expect(result).toMatchObject({
+      pid: started.pid,
+      status: 'failed',
+      exitCode: 143,
+    });
+  });
+
+  it.runIf(process.platform === 'win32')('runs a .cmd shim through the detached runner', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-node-service-'));
+    tempDirs.push(root);
+    const fixtureDir = join(root, 'cmd fixture');
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'work');
+    mkdirSync(fixtureDir, { recursive: true });
+    mkdirSync(workFolder, { recursive: true });
+    const scriptPath = join(fixtureDir, 'print-args.cjs');
+    const shimPath = join(fixtureDir, 'mock-forge.cmd');
+    writeFileSync(scriptPath, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+    writeFileSync(shimPath, `@ECHO off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`);
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: shimPath,
+        codex: shimPath,
+        gemini: shimPath,
+        forge: shimPath,
+        opencode: shimPath,
+      },
+    });
+    const prompt = 'special & | ^ %PATH% " prompt';
+
+    const started = await service.startProcess({ cwd: workFolder, model: 'forge', prompt });
+    const [result] = await service.waitForProcesses([started.pid], 5);
+    const processDir = join(
+      stateDir,
+      'cwds',
+      encodeCwd(realpathSync(workFolder)),
+      String(started.pid),
+    );
+
+    expect(result).toMatchObject({ status: 'completed', exitCode: 0 });
+    expect(JSON.parse(readFileSync(join(processDir, 'stdout.log'), 'utf8'))).toEqual([
+      '-C',
+      workFolder,
+      '-p',
+      prompt,
+    ]);
+  });
+});

--- a/src/__tests__/cli-process-service-windows-kill.test.ts
+++ b/src/__tests__/cli-process-service-windows-kill.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, spawnSync: vi.fn() };
+});
+
+import { CliProcessService } from '../cli-process-service.js';
+
+const tempDirs: string[] = [];
+const originalPlatform = process.platform;
+
+function encodeCwd(cwd: string): string {
+  return cwd
+    .split('')
+    .map((char) => (/^[A-Za-z0-9.-]$/.test(char) ? char : `_${char.charCodeAt(0).toString(16).padStart(2, '0')}`))
+    .join('');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  }
+});
+
+describe('CliProcessService Windows termination races', () => {
+  it('treats an ESRCH from the fallback runner kill as already terminated', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-windows-kill-'));
+    tempDirs.push(root);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'work');
+    const pid = 987654;
+    mkdirSync(workFolder, { recursive: true });
+    const processDir = join(
+      stateDir,
+      'cwds',
+      encodeCwd(realpathSync(workFolder)),
+      String(pid),
+    );
+    mkdirSync(processDir, { recursive: true });
+    writeFileSync(join(processDir, 'stdout.log'), '');
+    writeFileSync(join(processDir, 'stderr.log'), '');
+    writeFileSync(
+      join(processDir, 'meta.json'),
+      JSON.stringify({
+        pid,
+        prompt: 'termination race',
+        workFolder,
+        toolType: 'claude',
+        startTime: new Date().toISOString(),
+        stdoutPath: join(processDir, 'stdout.log'),
+        stderrPath: join(processDir, 'stderr.log'),
+        status: 'running',
+      }),
+    );
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: process.execPath,
+        codex: process.execPath,
+        gemini: process.execPath,
+        forge: process.execPath,
+        opencode: process.execPath,
+      },
+    });
+    let existenceChecks = 0;
+    const killSpy = vi.spyOn(globalThis.process, 'kill').mockImplementation((target, signal) => {
+      if (target === pid && signal === 0) {
+        existenceChecks++;
+        if (existenceChecks === 1) {
+          return true;
+        }
+        throw Object.assign(new Error('already exited'), { code: 'ESRCH' });
+      }
+      if (target === pid && signal === 'SIGTERM') {
+        throw Object.assign(new Error('already exited'), { code: 'ESRCH' });
+      }
+      return true;
+    });
+
+    await expect(service.killProcess(pid)).resolves.toEqual({
+      pid,
+      status: 'terminated',
+      message: 'Process terminated successfully',
+    });
+    expect(spawnSync).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/pid', String(pid), '/t', '/f'],
+      { stdio: 'ignore', windowsHide: true },
+    );
+    expect(killSpy).toHaveBeenCalledWith(pid, 'SIGTERM');
+  });
+});

--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -106,7 +106,7 @@ describe('CliProcessService', () => {
     expect(runResult.pid).toBeGreaterThan(0);
     expect(runResult.status).toBe('started');
     expect(existsSync(legacyWrapperPath)).toBe(false);
-    expect(existsSync(join(stateDir, 'detached-runner-v2.sh'))).toBe(true);
+    expect(existsSync(join(stateDir, 'detached-runner-v2.sh'))).toBe(false);
     expect(existsSync(join(processDir, 'meta.json'))).toBe(true);
     expect(existsSync(join(processDir, 'stdout.log'))).toBe(true);
     expect(existsSync(join(processDir, 'stderr.log'))).toBe(true);

--- a/src/__tests__/cli-utils.test.ts
+++ b/src/__tests__/cli-utils.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { accessSync } from 'node:fs';
+import { join } from 'node:path';
 
 vi.mock('node:fs', () => ({
   accessSync: vi.fn(),
@@ -11,6 +12,7 @@ const mockAccessSync = vi.mocked(accessSync);
 describe('cli-utils doctor status', () => {
   const originalEnv = process.env;
   const originalPlatform = process.platform;
+  const mockBinDir = join('mock-root', 'bin');
 
   beforeEach(() => {
     vi.resetModules();
@@ -21,7 +23,8 @@ describe('cli-utils doctor status', () => {
     delete process.env.GEMINI_CLI_NAME;
     delete process.env.FORGE_CLI_NAME;
     delete process.env.OPENCODE_CLI_NAME;
-    process.env.PATH = '/mock/bin:/usr/bin';
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.PATH = `${mockBinDir}:/usr/bin`;
   });
 
   afterEach(() => {
@@ -31,7 +34,7 @@ describe('cli-utils doctor status', () => {
 
   it('marks PATH binaries available when they are executable', async () => {
     mockAccessSync.mockImplementation((filePath) => {
-      if (filePath === '/mock/bin/claude') {
+      if (filePath === join(mockBinDir, 'claude')) {
         return undefined;
       }
       throw new Error('not executable');
@@ -48,7 +51,7 @@ describe('cli-utils doctor status', () => {
     });
     expect(status.claude).toEqual({
       configuredCommand: 'claude',
-      resolvedPath: '/mock/bin/claude',
+      resolvedPath: join(mockBinDir, 'claude'),
       available: true,
       lookup: 'path',
     });
@@ -141,31 +144,54 @@ describe('cli-utils doctor status', () => {
 
   it('supports Windows commands that already include an executable suffix', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    process.env.PATHEXT = '.EXE;.CMD';
     process.env.CLAUDE_CLI_NAME = 'claude.cmd';
-    process.env.PATH = '/mock/bin';
+    process.env.PATH = mockBinDir;
     mockAccessSync.mockImplementation((filePath) => {
-      if (filePath === '/mock/bin/claude.cmd') {
+      if (filePath === join(mockBinDir, 'claude.cmd')) {
         return undefined;
       }
       throw new Error('not executable');
     });
 
-    const { getCliDoctorStatus } = await import('../cli-utils.js');
+    const { findClaudeCli, getCliDoctorStatus } = await import('../cli-utils.js');
     const status = getCliDoctorStatus();
 
     expect(status.claude).toEqual({
       configuredCommand: 'claude.cmd',
-      resolvedPath: '/mock/bin/claude.cmd',
+      resolvedPath: join(mockBinDir, 'claude.cmd'),
       available: true,
       lookup: 'env',
     });
+    expect(findClaudeCli()).toBe(join(mockBinDir, 'claude.cmd'));
+  });
+
+  it('returns the resolved Windows path for an extensionless custom command name', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.CLAUDE_CLI_NAME = 'claude-custom';
+    process.env.PATH = mockBinDir;
+    mockAccessSync.mockImplementation((filePath) => {
+      if (filePath === join(mockBinDir, 'claude-custom.cmd')) {
+        return undefined;
+      }
+      throw new Error('not executable');
+    });
+
+    const { findClaudeCli, getCliDoctorStatus } = await import('../cli-utils.js');
+    const status = getCliDoctorStatus();
+
+    expect(status.claude).toEqual({
+      configuredCommand: 'claude-custom',
+      resolvedPath: join(mockBinDir, 'claude-custom.cmd'),
+      available: true,
+      lookup: 'env',
+    });
+    expect(findClaudeCli()).toBe(join(mockBinDir, 'claude-custom.cmd'));
   });
 
   it('supports forge lookup via FORGE_CLI_NAME', async () => {
     process.env.FORGE_CLI_NAME = 'forge-custom';
     mockAccessSync.mockImplementation((filePath) => {
-      if (filePath === '/mock/bin/forge-custom') {
+      if (filePath === join(mockBinDir, 'forge-custom')) {
         return undefined;
       }
       throw new Error('not executable');
@@ -176,7 +202,7 @@ describe('cli-utils doctor status', () => {
 
     expect(status.forge).toEqual({
       configuredCommand: 'forge-custom',
-      resolvedPath: '/mock/bin/forge-custom',
+      resolvedPath: join(mockBinDir, 'forge-custom'),
       available: true,
       lookup: 'env',
     });
@@ -186,7 +212,7 @@ describe('cli-utils doctor status', () => {
   it('supports OpenCode lookup via OPENCODE_CLI_NAME', async () => {
     process.env.OPENCODE_CLI_NAME = 'opencode-custom';
     mockAccessSync.mockImplementation((filePath) => {
-      if (filePath === '/mock/bin/opencode-custom') {
+      if (filePath === join(mockBinDir, 'opencode-custom')) {
         return undefined;
       }
       throw new Error('not executable');
@@ -197,10 +223,54 @@ describe('cli-utils doctor status', () => {
 
     expect(status.opencode).toEqual({
       configuredCommand: 'opencode-custom',
-      resolvedPath: '/mock/bin/opencode-custom',
+      resolvedPath: join(mockBinDir, 'opencode-custom'),
       available: true,
       lookup: 'env',
     });
     expect(findOpencodeCli()).toBe('opencode-custom');
+  });
+
+  it('uses a fixed Windows extension order and does not select an extensionless shim', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.PATH = mockBinDir;
+    const claudeCandidates: string[] = [];
+    mockAccessSync.mockImplementation((filePath) => {
+      if (String(filePath).startsWith(join(mockBinDir, 'claude'))) {
+        claudeCandidates.push(String(filePath));
+      }
+      if (filePath === join(mockBinDir, 'claude.cmd')) {
+        return undefined;
+      }
+      throw new Error('not executable');
+    });
+
+    const { getCliDoctorStatus } = await import('../cli-utils.js');
+    const status = getCliDoctorStatus();
+
+    expect(status.claude.resolvedPath).toBe(join(mockBinDir, 'claude.cmd'));
+    expect(claudeCandidates).toEqual([
+      join(mockBinDir, 'claude.exe'),
+      join(mockBinDir, 'claude.cmd'),
+    ]);
+    expect(claudeCandidates).not.toContain(join(mockBinDir, 'claude'));
+  });
+
+  it('keeps the extensionless PATH lookup unchanged on macOS', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    process.env.PATH = `${mockBinDir}:/usr/bin`;
+    mockAccessSync.mockImplementation((filePath) => {
+      if (filePath === join(mockBinDir, 'claude')) {
+        return undefined;
+      }
+      throw new Error('not executable');
+    });
+
+    const { getCliDoctorStatus } = await import('../cli-utils.js');
+    const status = getCliDoctorStatus();
+
+    expect(status.claude.resolvedPath).toBe(join(mockBinDir, 'claude'));
+    expect(mockAccessSync.mock.calls.map(([filePath]) => filePath)).not.toContain(
+      join(mockBinDir, 'claude.exe'),
+    );
   });
 });

--- a/src/__tests__/detached-runner.test.ts
+++ b/src/__tests__/detached-runner.test.ts
@@ -1,0 +1,304 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const runnerPath = fileURLToPath(new URL('../detached-runner.cjs', import.meta.url));
+const tempDirs: string[] = [];
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runDetachedRunner(code: string): Promise<{
+  exitCode: number | null;
+  processDir: string;
+}> {
+  const stateDir = mkdtempSync(join(tmpdir(), 'ai-cli-node-runner-'));
+  tempDirs.push(stateDir);
+  const cwdKey = 'test-cwd';
+  const runner = spawn(
+    process.execPath,
+    [runnerPath, stateDir, cwdKey, process.execPath, '-e', code],
+    { stdio: 'ignore', windowsHide: true },
+  );
+  const pid = runner.pid;
+  if (!pid) {
+    throw new Error('Failed to start detached runner test process');
+  }
+
+  const [exitCode] = await once(runner, 'close') as [number | null];
+  return {
+    exitCode,
+    processDir: join(stateDir, 'cwds', cwdKey, String(pid)),
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  }
+});
+
+describe('detached Node.js runner', () => {
+  it('captures output and persists a successful exit on every platform', async () => {
+    const { exitCode, processDir } = await runDetachedRunner(
+      "process.stdout.write('runner stdout'); process.stderr.write('runner stderr');",
+    );
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(processDir, 'stdout.log'), 'utf8')).toBe('runner stdout');
+    expect(readFileSync(join(processDir, 'stderr.log'), 'utf8')).toBe('runner stderr');
+    expect(JSON.parse(readFileSync(join(processDir, 'exit-status.json'), 'utf8'))).toEqual({
+      status: 'completed',
+      exitCode: 0,
+    });
+  });
+
+  it('persists command startup failures instead of crashing its parent', async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'ai-cli-node-runner-'));
+    tempDirs.push(stateDir);
+    const cwdKey = 'missing-command';
+    const missingCommand = join(stateDir, 'does-not-exist');
+    const runner = spawn(
+      process.execPath,
+      [runnerPath, stateDir, cwdKey, missingCommand],
+      { stdio: 'ignore', windowsHide: true },
+    );
+    const pid = runner.pid;
+    if (!pid) {
+      throw new Error('Failed to start detached runner test process');
+    }
+
+    const [exitCode] = await once(runner, 'close') as [number | null];
+    const processDir = join(stateDir, 'cwds', cwdKey, String(pid));
+
+    expect(exitCode).toBe(1);
+    expect(existsSync(join(processDir, 'exit-status.json'))).toBe(true);
+    expect(JSON.parse(readFileSync(join(processDir, 'exit-status.json'), 'utf8'))).toEqual({
+      status: 'failed',
+      exitCode: 1,
+    });
+    expect(readFileSync(join(processDir, 'stderr.log'), 'utf8')).toContain('Detached runner error:');
+  });
+
+  it.runIf(process.platform === 'win32')('resolves a bare .cmd command name on Windows', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-node-runner-'));
+    tempDirs.push(root);
+    const fixtureDir = join(root, 'custom bin');
+    const stateDir = join(root, 'state');
+    const cwdKey = 'bare-command';
+    mkdirSync(fixtureDir, { recursive: true });
+    const scriptPath = join(fixtureDir, 'print-bare.cjs');
+    const shimPath = join(fixtureDir, 'custom-agent.cmd');
+    writeFileSync(scriptPath, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+    writeFileSync(shimPath, `@ECHO off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`);
+    const runner = spawn(
+      process.execPath,
+      [runnerPath, stateDir, cwdKey, 'custom-agent', 'bare command', 'amp&value'],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+        env: { ...process.env, PATH: `${fixtureDir};${process.env.PATH || ''}` },
+      },
+    );
+    const pid = runner.pid;
+    if (!pid) {
+      throw new Error('Failed to start detached runner test process');
+    }
+
+    const [exitCode] = await once(runner, 'close') as [number | null];
+    const processDir = join(stateDir, 'cwds', cwdKey, String(pid));
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(readFileSync(join(processDir, 'stdout.log'), 'utf8'))).toEqual([
+      'bare command',
+      'amp&value',
+    ]);
+  });
+
+  it('terminates the spawned child when child PID persistence fails', async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'ai-cli-node-runner-'));
+    tempDirs.push(stateDir);
+    const preloadPath = join(stateDir, 'fail-child-pid-write.cjs');
+    const observedPidPath = join(stateDir, 'observed-child-pid');
+    writeFileSync(
+      preloadPath,
+      `'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const originalWriteFileSync = fs.writeFileSync.bind(fs);
+fs.writeFileSync = (filePath, ...args) => {
+  if (path.basename(String(filePath)) === 'child-pid') {
+    originalWriteFileSync(process.env.AI_CLI_TEST_OBSERVED_PID_PATH, String(args[0]));
+    const error = new Error('injected child-pid write failure');
+    error.code = 'EACCES';
+    throw error;
+  }
+  return originalWriteFileSync(filePath, ...args);
+};
+`,
+    );
+    const cwdKey = 'pid-write-failure';
+    const runner = spawn(
+      process.execPath,
+      [
+        '--require',
+        preloadPath,
+        runnerPath,
+        stateDir,
+        cwdKey,
+        process.execPath,
+        '-e',
+        'setInterval(() => {}, 1000)',
+      ],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+        env: {
+          ...process.env,
+          AI_CLI_TEST_OBSERVED_PID_PATH: observedPidPath,
+        },
+      },
+    );
+    const pid = runner.pid;
+    if (!pid) {
+      throw new Error('Failed to start detached runner test process');
+    }
+
+    const [exitCode] = await once(runner, 'close') as [number | null];
+    const processDir = join(stateDir, 'cwds', cwdKey, String(pid));
+    const childPid = Number.parseInt(readFileSync(observedPidPath, 'utf8').trim(), 10);
+
+    expect(exitCode).toBe(1);
+    await expect.poll(() => isProcessRunning(childPid), { timeout: 2000 }).toBe(false);
+    expect(readFileSync(join(processDir, 'stderr.log'), 'utf8')).toContain(
+      'injected child-pid write failure',
+    );
+    expect(JSON.parse(readFileSync(join(processDir, 'exit-status.json'), 'utf8'))).toEqual({
+      status: 'failed',
+      exitCode: 1,
+    });
+  });
+
+  it('terminates the spawned child when closing a log descriptor fails', async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'ai-cli-node-runner-'));
+    tempDirs.push(stateDir);
+    const preloadPath = join(stateDir, 'fail-log-close.cjs');
+    writeFileSync(
+      preloadPath,
+      `'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const originalOpenSync = fs.openSync.bind(fs);
+const originalCloseSync = fs.closeSync.bind(fs);
+const logFds = new Set();
+let injected = false;
+fs.openSync = (filePath, ...args) => {
+  const fd = originalOpenSync(filePath, ...args);
+  if (path.basename(String(filePath)) === 'stdout.log' || path.basename(String(filePath)) === 'stderr.log') {
+    logFds.add(fd);
+  }
+  return fd;
+};
+fs.closeSync = (fd) => {
+  if (!injected && logFds.has(fd)) {
+    injected = true;
+    const error = new Error('injected log close failure');
+    error.code = 'EIO';
+    throw error;
+  }
+  return originalCloseSync(fd);
+};
+`,
+    );
+    const cwdKey = 'log-close-failure';
+    const runner = spawn(
+      process.execPath,
+      [
+        '--require',
+        preloadPath,
+        runnerPath,
+        stateDir,
+        cwdKey,
+        process.execPath,
+        '-e',
+        'setInterval(() => {}, 1000)',
+      ],
+      { stdio: 'ignore', windowsHide: true },
+    );
+    const pid = runner.pid;
+    if (!pid) {
+      throw new Error('Failed to start detached runner test process');
+    }
+
+    const [exitCode] = await once(runner, 'close') as [number | null];
+    const processDir = join(stateDir, 'cwds', cwdKey, String(pid));
+    const childPid = Number.parseInt(readFileSync(join(processDir, 'child-pid'), 'utf8').trim(), 10);
+
+    expect(exitCode).toBe(1);
+    await expect.poll(() => isProcessRunning(childPid), { timeout: 2000 }).toBe(false);
+    expect(readFileSync(join(processDir, 'stderr.log'), 'utf8')).toContain(
+      'injected log close failure',
+    );
+  });
+
+  it('truncates stale logs before starting a reused runner PID directory', async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'ai-cli-node-runner-'));
+    tempDirs.push(stateDir);
+    const preloadPath = join(stateDir, 'seed-stale-logs.cjs');
+    const cwdKey = 'stale-logs';
+    writeFileSync(
+      preloadPath,
+      `'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const processDir = path.join(process.env.AI_CLI_TEST_STATE_DIR, 'cwds', process.env.AI_CLI_TEST_CWD_KEY, String(process.pid));
+fs.mkdirSync(processDir, { recursive: true });
+fs.writeFileSync(path.join(processDir, 'stdout.log'), 'stale stdout');
+fs.writeFileSync(path.join(processDir, 'stderr.log'), 'stale stderr');
+`,
+    );
+    const runner = spawn(
+      process.execPath,
+      [
+        '--require',
+        preloadPath,
+        runnerPath,
+        stateDir,
+        cwdKey,
+        process.execPath,
+        '-e',
+        "process.stdout.write('fresh stdout'); process.stderr.write('fresh stderr');",
+      ],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+        env: {
+          ...process.env,
+          AI_CLI_TEST_STATE_DIR: stateDir,
+          AI_CLI_TEST_CWD_KEY: cwdKey,
+        },
+      },
+    );
+    const pid = runner.pid;
+    if (!pid) {
+      throw new Error('Failed to start detached runner test process');
+    }
+
+    const [exitCode] = await once(runner, 'close') as [number | null];
+    const processDir = join(stateDir, 'cwds', cwdKey, String(pid));
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(processDir, 'stdout.log'), 'utf8')).toBe('fresh stdout');
+    expect(readFileSync(join(processDir, 'stderr.log'), 'utf8')).toBe('fresh stderr');
+  });
+});

--- a/src/__tests__/edge-cases.test.ts
+++ b/src/__tests__/edge-cases.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createTestClient, MCPTestClient } from './utils/mcp-client.js';
@@ -159,18 +159,17 @@ describe('Claude Code Edge Cases', () => {
     });
   });
 
-  describe('Path Traversal', () => {
-    it('should prevent path traversal attacks', async () => {
-      const maliciousPath = join(testDir, '..', '..', 'etc', 'passwd');
-      
-      // Server resolves paths and checks existence
-      // The path /etc/passwd may exist but be a file, not a directory
+  describe('Invalid Working Directory', () => {
+    it('should reject a workFolder that is a file', async () => {
+      const workFolderFile = join(testDir, 'not-a-directory');
+      writeFileSync(workFolderFile, 'not a directory');
+
       await expect(
         client.callTool('run', {
           prompt: 'Read file',
-          workFolder: maliciousPath,
+          workFolder: workFolderFile,
         })
-      ).rejects.toThrow(/(does not exist|ENOTDIR)/i);
+      ).rejects.toThrow('Failed to start claude CLI process');
     });
   });
 });

--- a/src/__tests__/error-cases.test.ts
+++ b/src/__tests__/error-cases.test.ts
@@ -50,6 +50,7 @@ describe('Error Handling Tests', () => {
   let consoleErrorSpy: any;
   let originalEnv: any;
   let errorHandler: any = null;
+  const originalPlatform = process.platform;
 
   function setupServerMock() {
     errorHandler = null;
@@ -73,11 +74,13 @@ describe('Error Handling Tests', () => {
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     originalEnv = { ...process.env };
     process.env = { ...originalEnv };
+    Object.defineProperty(process, 'platform', { value: 'linux' });
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     process.env = originalEnv;
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
   describe('CallToolRequest Error Cases', () => {

--- a/src/__tests__/mcp-spawn-failure.test.ts
+++ b/src/__tests__/mcp-spawn-failure.test.ts
@@ -1,0 +1,107 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function currentEnvironment(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+}
+
+describe('MCP server spawn failure isolation', () => {
+  it('keeps serving requests after a CLI fails before receiving a PID', async () => {
+    const missingCommand = join(process.cwd(), `missing-mcp-cli-${process.pid}-${Date.now()}`);
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['--import', 'tsx', 'src/server.ts'],
+      cwd: process.cwd(),
+      env: {
+        ...currentEnvironment(),
+        VITEST: '',
+        CLAUDE_CLI_NAME: missingCommand,
+        CODEX_CLI_NAME: missingCommand,
+        GEMINI_CLI_NAME: missingCommand,
+        FORGE_CLI_NAME: missingCommand,
+        OPENCODE_CLI_NAME: missingCommand,
+      },
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'spawn-failure-test', version: '1.0.0' });
+
+    try {
+      await client.connect(transport);
+      await expect(client.callTool({
+        name: 'run',
+        arguments: {
+          prompt: 'startup failure test',
+          workFolder: process.cwd(),
+        },
+      })).rejects.toThrow('Failed to start claude CLI process');
+
+      const tools = await client.listTools();
+      expect(tools.tools.some((tool) => tool.name === 'doctor')).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it.runIf(process.platform === 'win32')('runs a .cmd CLI through the stdio MCP server', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-mcp-cmd-'));
+    const fixtureDir = join(root, 'cmd fixture');
+    const workFolder = join(root, 'work');
+    mkdirSync(fixtureDir, { recursive: true });
+    mkdirSync(workFolder, { recursive: true });
+    const scriptPath = join(fixtureDir, 'mock-claude.cjs');
+    const shimPath = join(fixtureDir, 'mock-claude.cmd');
+    writeFileSync(
+      scriptPath,
+      `const args = process.argv.slice(2);\nconst promptIndex = args.indexOf('-p');\nconsole.log(JSON.stringify({ type: 'result', result: args[promptIndex + 1], is_error: false }));\n`,
+    );
+    writeFileSync(shimPath, `@ECHO off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`);
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['--import', 'tsx', 'src/server.ts'],
+      cwd: process.cwd(),
+      env: {
+        ...currentEnvironment(),
+        VITEST: '',
+        CLAUDE_CLI_NAME: shimPath,
+        CODEX_CLI_NAME: shimPath,
+        GEMINI_CLI_NAME: shimPath,
+        FORGE_CLI_NAME: shimPath,
+        OPENCODE_CLI_NAME: shimPath,
+      },
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'cmd-spawn-test', version: '1.0.0' });
+    const prompt = 'MCP .cmd prompt & | ^ %PATH% " preserved';
+
+    try {
+      await client.connect(transport);
+      const runResponse: any = await client.callTool({
+        name: 'run',
+        arguments: { prompt, workFolder },
+      });
+      const started = JSON.parse(runResponse.content[0].text);
+      const waitResponse: any = await client.callTool({
+        name: 'wait',
+        arguments: { pids: [started.pid], timeout: 5, verbose: true },
+      });
+      const [result] = JSON.parse(waitResponse.content[0].text);
+
+      expect(result).toMatchObject({
+        pid: started.pid,
+        agent: 'claude',
+        status: 'completed',
+        exitCode: 0,
+        agentOutput: { result: prompt, is_error: false },
+      });
+    } finally {
+      await client.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/package-smoke.test.ts
+++ b/src/__tests__/package-smoke.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const tempDirs: string[] = [];
@@ -20,12 +20,14 @@ const expectedPackageFiles = [
   'dist/cli-process-service.js',
   'dist/cli-utils.js',
   'dist/cli.js',
+  'dist/detached-runner.cjs',
   'dist/model-catalog.js',
   'dist/parsers.js',
   'dist/peek.js',
   'dist/process-result.js',
   'dist/process-service.js',
   'dist/server.js',
+  'dist/spawn-cli.js',
   'package.json',
   'server.json',
 ].sort();
@@ -53,9 +55,16 @@ afterEach(() => {
 describe('npm package smoke', () => {
   it('packs only the runtime files needed by the published package', () => {
     const packDir = makeTempDir('ai-cli-pack-smoke-');
+    const npmArgs = ['pack', '--json', '--pack-destination', packDir];
+    const executable = process.platform === 'win32' ? process.execPath : 'npm';
+    if (process.platform === 'win32') {
+      npmArgs.unshift(
+        process.env.npm_execpath || join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+      );
+    }
     const output = execFileSync(
-      'npm',
-      ['pack', '--json', '--pack-destination', packDir],
+      executable,
+      npmArgs,
       {
         cwd: process.cwd(),
         encoding: 'utf8',

--- a/src/__tests__/process-management.test.ts
+++ b/src/__tests__/process-management.test.ts
@@ -46,6 +46,7 @@ describe('Process Management Tests', () => {
   let originalEnv: any;
   let mockServerInstance: any;
   let handlers: Map<string, Function>;
+  const originalPlatform = process.platform;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -53,6 +54,7 @@ describe('Process Management Tests', () => {
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     originalEnv = { ...process.env };
     process.env = { ...originalEnv };
+    Object.defineProperty(process, 'platform', { value: 'linux' });
     handlers = new Map();
     
     // Set up default mocks
@@ -63,6 +65,7 @@ describe('Process Management Tests', () => {
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     process.env = originalEnv;
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
   async function setupServer() {
@@ -697,6 +700,9 @@ Unicodeテスト: 🎌 🗾 ✨
         expect(error.message).toContain('Failed to start claude CLI process');
         expect(error.code).toBe('InternalError');
       }
+
+      expect(mockProcess.listenerCount('error')).toBeGreaterThan(0);
+      expect(() => mockProcess.emit('error', new Error('spawn ENOENT'))).not.toThrow();
     });
   });
 

--- a/src/__tests__/process-service-startup.test.ts
+++ b/src/__tests__/process-service-startup.test.ts
@@ -1,0 +1,45 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ProcessService } from '../process-service.js';
+
+describe('ProcessService startup failures', () => {
+  it('consumes the child error event when spawning fails before a PID is assigned', async () => {
+    const missingCommand = join(process.cwd(), `missing-ai-cli-${process.pid}-${Date.now()}`);
+    const service = new ProcessService({
+      cliPaths: {
+        claude: missingCommand,
+        codex: missingCommand,
+        gemini: missingCommand,
+        forge: missingCommand,
+        opencode: missingCommand,
+      },
+    });
+
+    expect(() => service.startProcess({
+      prompt: 'startup failure test',
+      workFolder: process.cwd(),
+    })).toThrow('Failed to start claude CLI process');
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(service.listProcesses()).toEqual([]);
+  });
+
+  it.runIf(process.platform === 'win32')('rejects a missing bare command before reporting started', () => {
+    const missingCommand = `missing-ai-cli-${process.pid}-${Date.now()}`;
+    const service = new ProcessService({
+      cliPaths: {
+        claude: missingCommand,
+        codex: missingCommand,
+        gemini: missingCommand,
+        forge: missingCommand,
+        opencode: missingCommand,
+      },
+    });
+
+    expect(() => service.startProcess({
+      prompt: 'bare startup failure test',
+      workFolder: process.cwd(),
+    })).toThrow('Failed to start claude CLI process');
+    expect(service.listProcesses()).toEqual([]);
+  });
+});

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -61,6 +61,7 @@ describe('ClaudeCodeServer Unit Tests', () => {
   let consoleErrorSpy: any;
   let consoleWarnSpy: any;
   let originalEnv: any;
+  const originalPlatform = process.platform;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -71,6 +72,7 @@ describe('ClaudeCodeServer Unit Tests', () => {
     originalEnv = { ...process.env };
     // Reset env
     process.env = { ...originalEnv };
+    Object.defineProperty(process, 'platform', { value: 'linux' });
     mockAccessSync.mockImplementation((filePath) => {
       if (typeof filePath === 'string' && mockExistsSync(filePath)) {
         return undefined;
@@ -83,6 +85,7 @@ describe('ClaudeCodeServer Unit Tests', () => {
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
     process.env = originalEnv;
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
   describe('debugLog function', () => {

--- a/src/__tests__/spawn-cli-windows.test.ts
+++ b/src/__tests__/spawn-cli-windows.test.ts
@@ -1,0 +1,254 @@
+import { once } from 'node:events';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnCli } from '../spawn-cli.js';
+
+const tempDirs: string[] = [];
+const originalPath = process.env.PATH;
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  }
+  process.env.PATH = originalPath;
+});
+
+describe.skipIf(process.platform !== 'win32')('Windows CLI spawning', () => {
+  it('preserves spaces and cmd metacharacters when launching a global-style npm shim', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const fixtureDir = join(root, 'path with spaces');
+    mkdirSync(fixtureDir, { recursive: true });
+    const scriptPath = join(fixtureDir, 'print-args.cjs');
+    const shimPath = join(fixtureDir, 'mock-cli.cmd');
+    writeFileSync(scriptPath, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+    writeFileSync(
+      shimPath,
+      `@ECHO off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`,
+    );
+    const expectedArgs = [
+      'plain',
+      'space value',
+      'amp&ersand',
+      'pipe|value',
+      'less<more',
+      'caret^value',
+      'percent%PATH%',
+      'bang!value',
+      'quote"value',
+      'paren(value)',
+      'trailing\\',
+    ];
+
+    const child = spawnCli(shimPath, expectedArgs, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(expectedArgs);
+  });
+
+  it('resolves a bare command name through PATHEXT', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const fixtureDir = join(root, 'custom bin');
+    mkdirSync(fixtureDir, { recursive: true });
+    const scriptPath = join(fixtureDir, 'print-bare-args.cjs');
+    const shimPath = join(fixtureDir, 'custom-agent.cmd');
+    writeFileSync(scriptPath, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+    writeFileSync(shimPath, `@ECHO off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`);
+    process.env.PATH = `${fixtureDir};${originalPath || ''}`;
+
+    const child = spawnCli('custom-agent', ['bare command', 'amp&value'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(['bare command', 'amp&value']);
+  });
+
+  it('resolves a bare command from the requested working directory', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const scriptPath = join(root, 'print-cwd.cjs');
+    const shimPath = join(root, 'cwd-agent.cmd');
+    writeFileSync(scriptPath, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+    writeFileSync(shimPath, `@ECHO off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`);
+
+    const child = spawnCli('cwd-agent', ['cwd argument'], {
+      cwd: root,
+      env: { ...process.env, PATH: originalPath || '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(['cwd argument']);
+  });
+
+  it('resolves a bare command from a relative working directory', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const scriptPath = join(root, 'print-relative-cwd.cjs');
+    const shimPath = join(root, 'relative-cwd-agent.cmd');
+    writeFileSync(scriptPath, "process.stdout.write('relative cwd ok');\n");
+    writeFileSync(shimPath, `@ECHO off\r\n"${process.execPath}" "${scriptPath}"\r\n`);
+
+    const child = spawnCli('relative-cwd-agent', [], {
+      cwd: relative(process.cwd(), root),
+      env: { ...process.env, PATH: originalPath || '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(stdout).toBe('relative cwd ok');
+  });
+
+  it('resolves a bare command from the spawn environment PATH', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const fixtureDir = join(root, 'environment bin');
+    mkdirSync(fixtureDir, { recursive: true });
+    const scriptPath = join(fixtureDir, 'print-env.cjs');
+    const shimPath = join(fixtureDir, 'env-agent.cmd');
+    writeFileSync(scriptPath, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+    writeFileSync(shimPath, `@ECHO off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`);
+
+    const child = spawnCli('env-agent', ['env argument'], {
+      cwd: root,
+      env: { ...process.env, PATH: fixtureDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(['env argument']);
+  });
+
+  it('uses the last case-insensitive PATH key from the spawn environment', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const oldBin = join(root, 'old bin');
+    const newBin = join(root, 'new bin');
+    mkdirSync(oldBin, { recursive: true });
+    mkdirSync(newBin, { recursive: true });
+    const oldScript = join(oldBin, 'print-old.cjs');
+    const newScript = join(newBin, 'print-new.cjs');
+    writeFileSync(oldScript, "process.stdout.write('old');\n");
+    writeFileSync(newScript, "process.stdout.write('new');\n");
+    writeFileSync(join(oldBin, 'duplicate-agent.cmd'), `@ECHO off\r\n"${process.execPath}" "${oldScript}"\r\n`);
+    writeFileSync(join(newBin, 'duplicate-agent.cmd'), `@ECHO off\r\n"${process.execPath}" "${newScript}"\r\n`);
+    const childEnv = { ...process.env };
+    for (const key of Object.keys(childEnv)) {
+      if (key.toUpperCase() === 'PATH') {
+        delete childEnv[key];
+      }
+    }
+    childEnv.Path = oldBin;
+    childEnv.PATH = newBin;
+
+    const child = spawnCli('duplicate-agent', [], {
+      cwd: root,
+      env: childEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(stdout).toBe('new');
+  });
+
+  it('resolves relative PATH entries against the spawn working directory', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const fixtureDir = join(root, 'bin');
+    mkdirSync(fixtureDir, { recursive: true });
+    const scriptPath = join(fixtureDir, 'print-relative.cjs');
+    writeFileSync(scriptPath, "process.stdout.write('relative path ok');\n");
+    writeFileSync(
+      join(fixtureDir, 'relative-agent.cmd'),
+      `@ECHO off\r\n"${process.execPath}" "${scriptPath}"\r\n`,
+    );
+
+    const child = spawnCli('relative-agent', [], {
+      cwd: root,
+      env: { ...process.env, PATH: 'bin' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(stdout).toBe('relative path ok');
+  });
+
+  it('runs an absolute extensionless executable through its shebang', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-spawn-'));
+    tempDirs.push(root);
+    const scriptPath = join(root, 'extensionless-agent');
+    writeFileSync(
+      scriptPath,
+      `#!${process.execPath}\nprocess.stdout.write(JSON.stringify(process.argv.slice(2)));\n`,
+    );
+
+    const child = spawnCli(scriptPath, ['extensionless argument'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data) => { stderr += data.toString(); });
+    const [exitCode] = await once(child, 'close') as [number | null];
+
+    expect(exitCode, stderr).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(['extensionless argument']);
+  });
+
+  it('rejects a missing bare command before returning a child PID', () => {
+    const command = `missing-agent-${process.pid}-${Date.now()}`;
+
+    expect(() => spawnCli(command, [], { windowsHide: true })).toThrow(
+      `spawn ${command} ENOENT`,
+    );
+  });
+});

--- a/src/__tests__/utils/claude-mock.ts
+++ b/src/__tests__/utils/claude-mock.ts
@@ -1,5 +1,11 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
+
+export function getClaudeMockPath(binaryName: string = 'claude'): string {
+  const fileName = process.platform === 'win32' ? `${binaryName}.cmd` : binaryName;
+  return join(tmpdir(), 'claude-code-test-mock', fileName);
+}
 
 /**
  * Mock Claude CLI for testing
@@ -7,11 +13,18 @@ import { join, dirname } from 'node:path';
  */
 export class ClaudeMock {
   private mockPath: string;
+  private nodeScriptPath: string | null;
   private responses = new Map<string, string>();
 
   constructor(binaryName: string = 'claude') {
-    // Always use /tmp directory for mocks in tests
-    this.mockPath = join('/tmp', 'claude-code-test-mock', binaryName);
+    this.mockPath = getClaudeMockPath(binaryName);
+    this.nodeScriptPath = process.platform === 'win32'
+      ? join(dirname(this.mockPath), `${binaryName}.cjs`)
+      : null;
+  }
+
+  get path(): string {
+    return this.mockPath;
   }
 
   /**
@@ -21,6 +34,36 @@ export class ClaudeMock {
     const dir = dirname(this.mockPath);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
+    }
+
+    if (this.nodeScriptPath) {
+      const mockScript = `const args = process.argv.slice(2);
+let prompt = '';
+
+for (let index = 0; index < args.length; index += 1) {
+  if (args[index] === '-p' || args[index] === '--prompt') {
+    prompt = args[index + 1] || '';
+    index += 1;
+  }
+}
+
+if (prompt.includes('create') || prompt.includes('Create')) {
+  process.stdout.write('Created file successfully\\n');
+} else if (prompt.includes('git') && prompt.includes('commit')) {
+  process.stdout.write('Committed changes successfully\\n');
+} else if (prompt.includes('error')) {
+  process.stderr.write('Error: Mock error response\\n');
+  process.exitCode = 1;
+} else {
+  process.stdout.write('Command executed successfully\\n');
+}
+`;
+      writeFileSync(this.nodeScriptPath, mockScript);
+      writeFileSync(
+        this.mockPath,
+        `@ECHO off\r\n"${process.execPath}" "${this.nodeScriptPath}" %*\r\n`,
+      );
+      return;
     }
 
     // Create a simple bash script that echoes responses
@@ -76,6 +119,9 @@ fi
   async cleanup(): Promise<void> {
     const { rm } = await import('node:fs/promises');
     await rm(this.mockPath, { force: true });
+    if (this.nodeScriptPath) {
+      await rm(this.nodeScriptPath, { force: true });
+    }
   }
 
   /**

--- a/src/__tests__/utils/mcp-client.ts
+++ b/src/__tests__/utils/mcp-client.ts
@@ -1,5 +1,6 @@
 import { spawn, ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { getClaudeMockPath } from './claude-mock.js';
 
 export interface MCPResponse {
   jsonrpc: string;
@@ -157,7 +158,7 @@ export function createTestClient(options: {
 } = {}): MCPTestClient {
   const {
     serverPath = DEFAULT_SERVER_PATH,
-    claudeCliName = process.env.TEST_CLAUDE_CLI_NAME || '/tmp/claude-code-test-mock/claudeMocked',
+    claudeCliName = process.env.TEST_CLAUDE_CLI_NAME || getClaudeMockPath('claudeMocked'),
     debug = true,
     env = {},
   } = options;

--- a/src/__tests__/utils/persistent-mock.ts
+++ b/src/__tests__/utils/persistent-mock.ts
@@ -1,16 +1,15 @@
 import { ClaudeMock } from './claude-mock.js';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
 
 let sharedMock: ClaudeMock | null = null;
 const workerId = process.env.VITEST_WORKER_ID || process.env.VITEST_POOL_ID || process.pid.toString();
 const mockName = `claudeMocked-${workerId}`;
-const mockPath = join('/tmp', 'claude-code-test-mock', mockName);
 
 export async function getSharedMock(): Promise<ClaudeMock> {
   if (!sharedMock) {
     sharedMock = new ClaudeMock(mockName);
   }
+  const mockPath = sharedMock.path;
   
   // Always ensure mock exists
   if (!existsSync(mockPath)) {

--- a/src/__tests__/utils/test-helpers.ts
+++ b/src/__tests__/utils/test-helpers.ts
@@ -1,9 +1,8 @@
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { getClaudeMockPath } from './claude-mock.js';
 
 export function verifyMockExists(binaryName: string): boolean {
-  const mockPath = join('/tmp', 'claude-code-test-mock', binaryName);
-  return existsSync(mockPath);
+  return existsSync(getClaudeMockPath(binaryName));
 }
 
 export async function ensureMockExists(mock: any): Promise<void> {

--- a/src/__tests__/version-print.test.ts
+++ b/src/__tests__/version-print.test.ts
@@ -13,6 +13,7 @@ describe('Version Print on First Use', () => {
   let client: MCPTestClient;
   let testDir: string;
   let consoleErrorSpy: any;
+  let startedPids: number[];
 
   beforeEach(async () => {
     // Ensure mock exists
@@ -20,6 +21,7 @@ describe('Version Print on First Use', () => {
 
     // Create a temporary directory for test files
     testDir = mkdtempSync(join(tmpdir(), 'claude-code-test-'));
+    startedPids = [];
 
     // Spy on console.error
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -29,11 +31,15 @@ describe('Version Print on First Use', () => {
   });
 
   afterEach(async () => {
+    if (startedPids.length > 0) {
+      await client.callTool('wait', { pids: startedPids, timeout: 5 });
+    }
+
     // Disconnect client
     await client.disconnect();
     
     // Clean up test directory
-    rmSync(testDir, { recursive: true, force: true });
+    rmSync(testDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
     
     // Restore console.error spy
     consoleErrorSpy.mockRestore();
@@ -41,10 +47,11 @@ describe('Version Print on First Use', () => {
 
   it('should print version and startup time only on first use', async () => {
     // First tool call
-    await client.callTool('run', {
+    const firstRun = await client.callTool('run', {
       prompt: 'echo "test 1"',
       workFolder: testDir,
     });
+    startedPids.push(JSON.parse(firstRun[0].text).pid);
     
     // Find the version print in the console.error calls
     const findVersionCall = (calls: any[][]) => {
@@ -64,20 +71,22 @@ describe('Version Print on First Use', () => {
     consoleErrorSpy.mockClear();
     
     // Second tool call
-    await client.callTool('run', {
+    const secondRun = await client.callTool('run', {
       prompt: 'echo "test 2"',
       workFolder: testDir,
     });
+    startedPids.push(JSON.parse(secondRun[0].text).pid);
     
     // Check that version was NOT printed on second use
     const secondVersionCall = findVersionCall(consoleErrorSpy.mock.calls);
     expect(secondVersionCall).toBeUndefined();
     
     // Third tool call
-    await client.callTool('run', {
+    const thirdRun = await client.callTool('run', {
       prompt: 'echo "test 3"',
       workFolder: testDir,
     });
+    startedPids.push(JSON.parse(thirdRun[0].text).pid);
     
     // Should still not have been called with version print
     const thirdVersionCall = findVersionCall(consoleErrorSpy.mock.calls);

--- a/src/__tests__/wait.test.ts
+++ b/src/__tests__/wait.test.ts
@@ -57,6 +57,7 @@ describe('Wait Tool Tests', () => {
   let handlers: Map<string, Function>;
   let mockServerInstance: any;
   let server: any;
+  const originalPlatform = process.platform;
 
   // Setup function to initialize server with mocks
   const setupServer = async () => {
@@ -81,6 +82,7 @@ describe('Wait Tool Tests', () => {
   };
 
   beforeEach(async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
     mockHomedir.mockReturnValue('/home/user');
     mockExistsSync.mockReturnValue(true);
     await setupServer();
@@ -89,6 +91,7 @@ describe('Wait Tool Tests', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
   const createMockProcess = (pid: number) => {

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -1,7 +1,6 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import {
   appendFileSync,
-  chmodSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -15,6 +14,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { join, basename, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
@@ -297,7 +297,7 @@ export class CliProcessService {
       };
     }
 
-    this.killPidOrGroup(pid, 'SIGTERM');
+    this.killPidOrGroup(refreshed, 'SIGTERM');
     await this.waitForProcessExit(pid, 250);
 
     if (isProcessRunning(pid)) {
@@ -355,12 +355,14 @@ export class CliProcessService {
     model: string | undefined,
   ): Promise<{ pid: number; status: 'started'; agent: AgentType; message: string }> {
     const cwdKey = this.resolveCwdKey(cmd.cwd);
-    const wrapperPath = this.ensureDetachedWrapperScript();
+    const runnerPath = this.resolveDetachedRunnerPath();
+    this.removeLegacyDetachedWrappers();
 
-    const childProcess = spawn(wrapperPath, [this.stateDir, cwdKey, cmd.cliPath, ...cmd.args], {
+    const childProcess = spawn(process.execPath, [runnerPath, this.stateDir, cwdKey, cmd.cliPath, ...cmd.args], {
       cwd: cmd.cwd,
       detached: true,
       stdio: 'ignore',
+      windowsHide: true,
     });
 
     const pid = childProcess.pid;
@@ -574,71 +576,16 @@ export class CliProcessService {
     return join(processDir, 'exit-status.json');
   }
 
-  private resolveDetachedWrapperPath(): string {
-    return join(this.stateDir, 'detached-runner-v2.sh');
-  }
-
-  private ensureDetachedWrapperScript(): string {
-    const wrapperPath = this.resolveDetachedWrapperPath();
-    this.removeLegacyDetachedWrappers();
-    if (existsSync(wrapperPath)) {
-      return wrapperPath;
+  private resolveDetachedRunnerPath(): string {
+    const runnerPath = fileURLToPath(new URL('./detached-runner.cjs', import.meta.url));
+    if (!existsSync(runnerPath)) {
+      throw new Error(`Detached runner not found: ${runnerPath}`);
     }
-
-    writeFileSync(
-      wrapperPath,
-      `#!/bin/sh
-set +e
-state_dir="$1"
-cwd_key="$2"
-shift 2
-pid="$$"
-process_dir="$state_dir/cwds/$cwd_key/$pid"
-stdout_path="$process_dir/stdout.log"
-stderr_path="$process_dir/stderr.log"
-exit_meta_path="$process_dir/exit-status.json"
-mkdir -p "$process_dir"
-: > "$stdout_path"
-: > "$stderr_path"
-write_exit_status() {
-  status="$1"
-  exit_code="$2"
-  tmp_exit_meta_path="$exit_meta_path.$$"
-  printf '{\n  "status": "%s",\n  "exitCode": %s\n}\n' "$status" "$exit_code" > "$tmp_exit_meta_path"
-  mv "$tmp_exit_meta_path" "$exit_meta_path"
-}
-handle_signal() {
-  signal="$1"
-  exit_code="$2"
-  if [ -n "\${child_pid:-}" ]; then
-    kill "-$signal" "$child_pid" 2>/dev/null || true
-    wait "$child_pid" 2>/dev/null
-  fi
-  write_exit_status "failed" "$exit_code"
-  exit "$exit_code"
-}
-trap 'handle_signal TERM 143' TERM
-trap 'handle_signal INT 130' INT
-trap 'handle_signal HUP 129' HUP
-"$@" >> "$stdout_path" 2>> "$stderr_path" &
-child_pid="$!"
-wait "$child_pid"
-exit_code="$?"
-trap - TERM INT HUP
-status="completed"
-if [ "$exit_code" -ne 0 ]; then
-  status="failed"
-fi
-write_exit_status "$status" "$exit_code"
-exit "$exit_code"
-`,
-    );
-    chmodSync(wrapperPath, 0o755);
-    return wrapperPath;
+    return runnerPath;
   }
 
   private removeLegacyDetachedWrappers(): void {
-    for (const fileName of ['detached-runner-v1.sh']) {
+    for (const fileName of ['detached-runner-v1.sh', 'detached-runner-v2.sh']) {
       const legacyPath = join(this.stateDir, fileName);
       if (!existsSync(legacyPath)) {
         continue;
@@ -650,7 +597,38 @@ exit "$exit_code"
     }
   }
 
-  private killPidOrGroup(pid: number, signal: NodeJS.Signals): void {
+  private killPidOrGroup(process: StoredProcess, signal: NodeJS.Signals): void {
+    const pid = process.pid;
+    if (globalThis.process.platform === 'win32') {
+      if (signal === 'SIGTERM') {
+        const result = spawnSync('taskkill.exe', ['/pid', String(pid), '/t', '/f'], {
+          stdio: 'ignore',
+          windowsHide: true,
+        });
+        if (result.status === 0) {
+          return;
+        }
+      }
+      const childPid = this.readChildPid(process);
+      if (childPid && isProcessRunning(childPid)) {
+        try {
+          globalThis.process.kill(childPid, signal);
+        } catch (error: any) {
+          if (error.code !== 'ESRCH') {
+            throw error;
+          }
+        }
+      }
+      try {
+        globalThis.process.kill(pid, signal);
+      } catch (error: any) {
+        if (error.code !== 'ESRCH') {
+          throw error;
+        }
+      }
+      return;
+    }
+
     try {
       globalThis.process.kill(-pid, signal);
     } catch (error: any) {
@@ -663,6 +641,16 @@ exit "$exit_code"
       }
       globalThis.process.kill(pid, signal);
     }
+  }
+
+  private readChildPid(process: StoredProcess): number | null {
+    const childPidPath = join(this.resolveStoredProcessDir(process), 'child-pid');
+    if (!existsSync(childPidPath)) {
+      return null;
+    }
+
+    const childPid = Number.parseInt(readFileSync(childPidPath, 'utf8').trim(), 10);
+    return Number.isSafeInteger(childPid) && childPid > 0 ? childPid : null;
   }
 
   private async waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {

--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -43,31 +43,38 @@ export interface CliDoctorStatus {
   opencode: CliBinaryStatus;
 }
 
-function getPathDelimiter(): string {
-  return process.platform === 'win32' ? ';' : ':';
-}
-
-function getPathExtensions(): string[] {
-  if (process.platform !== 'win32') {
-    return [''];
+function getCommandCandidates(commandName: string): string[] {
+  if (process.platform !== 'win32' || /\.[^\\/.]+$/.test(commandName)) {
+    return [commandName];
   }
 
-  const rawPathext = process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM';
-  return ['', ...rawPathext.split(';').filter(Boolean)];
+  return ['.exe', '.cmd', '.bat', '.com'].map((extension) => `${commandName}${extension}`);
 }
 
-function findExecutableOnPath(commandName: string): string | null {
-  const rawPath = process.env.PATH || '';
-  if (!rawPath) {
+export function resolveCliCommandOnPath(
+  commandName: string,
+  options: { path?: string; pathBaseDirectory?: string; searchDirectories?: string[] } = {},
+): string | null {
+  const rawPath = options.path ?? process.env.PATH ?? '';
+  const pathDelimiter = process.platform === 'win32' ? ';' : ':';
+  const pathEntries = [
+    ...(options.searchDirectories || []),
+    ...rawPath.split(pathDelimiter),
+  ]
+    .filter(Boolean)
+    .map((entry) => (
+      options.pathBaseDirectory && !path.isAbsolute(entry)
+        ? path.resolve(options.pathBaseDirectory, entry)
+        : entry
+    ));
+  if (pathEntries.length === 0) {
     return null;
   }
-
-  const pathEntries = rawPath.split(getPathDelimiter()).filter(Boolean);
-  const extensions = getPathExtensions();
+  const candidates = getCommandCandidates(commandName);
 
   for (const entry of pathEntries) {
-    for (const extension of extensions) {
-      const candidate = join(entry, `${commandName}${extension}`);
+    for (const commandCandidate of candidates) {
+      const candidate = join(entry, commandCandidate);
       if (isExecutableFile(candidate)) {
         return candidate;
       }
@@ -122,7 +129,7 @@ function inspectCliBinary(options: {
       };
     }
 
-    const resolvedPath = findExecutableOnPath(configuredCommand);
+    const resolvedPath = resolveCliCommandOnPath(configuredCommand);
     return {
       configuredCommand,
       resolvedPath,
@@ -140,7 +147,7 @@ function inspectCliBinary(options: {
     };
   }
 
-  const resolvedPath = findExecutableOnPath(configuredCommand);
+  const resolvedPath = resolveCliCommandOnPath(configuredCommand);
   return {
     configuredCommand,
     resolvedPath,
@@ -155,6 +162,9 @@ function getCliCommandOrThrow(status: CliBinaryStatus): string {
   }
 
   if (status.lookup === 'env' && !path.isAbsolute(status.configuredCommand)) {
+    if (process.platform === 'win32' && status.resolvedPath) {
+      return status.resolvedPath;
+    }
     return status.configuredCommand;
   }
 

--- a/src/cross-spawn.d.ts
+++ b/src/cross-spawn.d.ts
@@ -1,0 +1,7 @@
+declare module 'cross-spawn' {
+  import type { ChildProcess, SpawnOptions } from 'node:child_process';
+
+  function crossSpawn(command: string, args: string[], options: SpawnOptions): ChildProcess;
+
+  export default crossSpawn;
+}

--- a/src/detached-runner.cjs
+++ b/src/detached-runner.cjs
@@ -1,0 +1,179 @@
+'use strict';
+
+const { spawn: nativeSpawn, spawnSync } = require('node:child_process');
+const crossSpawn = require('cross-spawn');
+const {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  writeFileSync,
+} = require('node:fs');
+const { join } = require('node:path');
+
+const SIGNAL_EXIT_CODES = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+function spawnCli(command, args, options) {
+  if (process.platform === 'win32') {
+    return crossSpawn(command, args, options);
+  }
+  return nativeSpawn(command, args, options);
+}
+
+const [stateDir, cwdKey, command, ...args] = process.argv.slice(2);
+
+if (!stateDir || !cwdKey || !command) {
+  process.stderr.write('Usage: detached-runner.cjs <state-dir> <cwd-key> <command> [...args]\n');
+  process.exit(2);
+}
+
+const pid = process.pid;
+const processDir = join(stateDir, 'cwds', cwdKey, String(pid));
+const stdoutPath = join(processDir, 'stdout.log');
+const stderrPath = join(processDir, 'stderr.log');
+const exitStatusPath = join(processDir, 'exit-status.json');
+const childPidPath = join(processDir, 'child-pid');
+
+mkdirSync(processDir, { recursive: true });
+
+let child;
+let finished = false;
+let terminationExitCode;
+
+function appendRunnerError(error) {
+  try {
+    appendFileSync(stderrPath, `\nDetached runner error: ${error.message}\n`);
+  } catch {
+    // There is nowhere else safe to report an error from a detached process.
+  }
+}
+
+function writeExitStatus(status, exitCode) {
+  const tempPath = `${exitStatusPath}.${pid}.${Date.now()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify({ status, exitCode }, null, 2)}\n`);
+  renameSync(tempPath, exitStatusPath);
+}
+
+function finish(status, exitCode) {
+  if (finished) {
+    return;
+  }
+  finished = true;
+
+  try {
+    writeExitStatus(status, exitCode);
+  } catch (error) {
+    appendRunnerError(error);
+    process.exit(1);
+  }
+
+  process.exit(exitCode);
+}
+
+function terminateChild(signal, exitCode) {
+  if (terminationExitCode !== undefined) {
+    return;
+  }
+
+  terminationExitCode = exitCode;
+  if (!child || !child.pid) {
+    finish('failed', terminationExitCode);
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32' && (signal === 'SIGTERM' || signal === 'SIGKILL')) {
+      const result = spawnSync('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      if (result.status === 0) {
+        return;
+      }
+    }
+
+    if (!child.kill(signal)) {
+      finish('failed', terminationExitCode);
+    }
+  } catch (error) {
+    appendRunnerError(error);
+    finish('failed', terminationExitCode);
+  }
+}
+
+function handleSignal(signal) {
+  terminateChild(signal, SIGNAL_EXIT_CODES[signal] || 1);
+}
+
+function attachChildListeners() {
+  child.once('error', (error) => {
+    appendRunnerError(error);
+    finish('failed', terminationExitCode || 1);
+  });
+
+  child.once('close', (code, signal) => {
+    if (terminationExitCode !== undefined) {
+      finish('failed', terminationExitCode);
+      return;
+    }
+
+    const exitCode = code === null ? SIGNAL_EXIT_CODES[signal] || 1 : code;
+    finish(exitCode === 0 ? 'completed' : 'failed', exitCode);
+  });
+}
+
+function closeLogDescriptors() {
+  let closeError;
+  for (const fd of [stdoutFd, stderrFd]) {
+    if (fd === undefined) {
+      continue;
+    }
+    try {
+      closeSync(fd);
+    } catch (error) {
+      closeError ||= error;
+      appendRunnerError(error);
+    }
+  }
+
+  if (closeError && child && !finished) {
+    terminateChild('SIGKILL', 1);
+  }
+}
+
+for (const signal of Object.keys(SIGNAL_EXIT_CODES)) {
+  process.on(signal, () => handleSignal(signal));
+}
+
+let stdoutFd;
+let stderrFd;
+
+try {
+  stdoutFd = openSync(stdoutPath, 'w');
+  stderrFd = openSync(stderrPath, 'w');
+  child = spawnCli(command, args, {
+    cwd: process.cwd(),
+    detached: false,
+    stdio: ['ignore', stdoutFd, stderrFd],
+    windowsHide: true,
+  });
+  attachChildListeners();
+  if (child.pid) {
+    try {
+      writeFileSync(childPidPath, `${child.pid}\n`);
+    } catch (error) {
+      appendRunnerError(error);
+      terminateChild('SIGKILL', 1);
+    }
+  }
+} catch (error) {
+  appendRunnerError(error);
+  finish('failed', 1);
+} finally {
+  closeLogDescriptors();
+}

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import {
@@ -11,6 +11,7 @@ import {
   type PeekResponse,
 } from './peek.js';
 import { buildProcessResult } from './process-result.js';
+import { spawnCli } from './spawn-cli.js';
 
 export type AgentType = 'claude' | 'codex' | 'gemini' | 'forge' | 'opencode';
 export type ProcessStatus = 'running' | 'completed' | 'failed';
@@ -86,10 +87,23 @@ export class ProcessService {
     });
 
     const { cliPath, args: processArgs, cwd: effectiveCwd, agent, prompt } = cmd;
-    const childProcess = spawn(cliPath, processArgs, {
-      cwd: effectiveCwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      detached: false,
+    let childProcess: ChildProcess;
+    try {
+      childProcess = spawnCli(cliPath, processArgs, {
+        cwd: effectiveCwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+      });
+    } catch {
+      throw new Error(`Failed to start ${agent} CLI process`);
+    }
+
+    let processEntry: TrackedProcess | undefined;
+    childProcess.on('error', (error) => {
+      if (processEntry) {
+        processEntry.status = 'failed';
+        processEntry.stderr += `\nProcess error: ${error.message}`;
+      }
     });
 
     const pid = childProcess.pid;
@@ -97,7 +111,7 @@ export class ProcessService {
       throw new Error(`Failed to start ${agent} CLI process`);
     }
 
-    const processEntry: TrackedProcess = {
+    processEntry = {
       pid,
       process: childProcess,
       prompt,
@@ -112,14 +126,14 @@ export class ProcessService {
 
     this.processManager.set(pid, processEntry);
 
-    childProcess.stdout.on('data', (data) => {
+    childProcess.stdout?.on('data', (data) => {
       const entry = this.processManager.get(pid);
       if (entry) {
         entry.stdout += data.toString();
       }
     });
 
-    childProcess.stderr.on('data', (data) => {
+    childProcess.stderr?.on('data', (data) => {
       const entry = this.processManager.get(pid);
       if (entry) {
         entry.stderr += data.toString();
@@ -131,14 +145,6 @@ export class ProcessService {
       if (entry) {
         entry.status = code === 0 ? 'completed' : 'failed';
         entry.exitCode = code !== null ? code : undefined;
-      }
-    });
-
-    childProcess.on('error', (error) => {
-      const entry = this.processManager.get(pid);
-      if (entry) {
-        entry.status = 'failed';
-        entry.stderr += `\nProcess error: ${error.message}`;
       }
     });
 

--- a/src/spawn-cli.ts
+++ b/src/spawn-cli.ts
@@ -1,0 +1,55 @@
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { accessSync, constants } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import crossSpawn from 'cross-spawn';
+import { resolveCliCommandOnPath } from './cli-utils.js';
+
+function getEnvironmentPath(env: NodeJS.ProcessEnv | undefined): string | undefined {
+  const source = env || process.env;
+  const pathKey = Object.keys(source).reverse().find((key) => key.toUpperCase() === 'PATH');
+  return pathKey ? source[pathKey] : process.env.PATH;
+}
+
+function getSpawnCwd(options: SpawnOptions): string {
+  if (!options.cwd) {
+    return process.cwd();
+  }
+  const cwd = typeof options.cwd === 'string' ? options.cwd : fileURLToPath(options.cwd);
+  return isAbsolute(cwd) ? cwd : resolve(process.cwd(), cwd);
+}
+
+function resolveWindowsCommand(command: string, options: SpawnOptions): string {
+  const isBareCommand = !/[\\/]/.test(command);
+  if (isBareCommand) {
+    const resolvedPath = resolveCliCommandOnPath(command, {
+      path: getEnvironmentPath(options.env),
+      pathBaseDirectory: getSpawnCwd(options),
+      searchDirectories: [getSpawnCwd(options)],
+    });
+    if (resolvedPath) {
+      return resolvedPath;
+    }
+  } else {
+    const resolvedCommand = isAbsolute(command) ? command : resolve(getSpawnCwd(options), command);
+    try {
+      accessSync(resolvedCommand, constants.X_OK);
+      return resolvedCommand;
+    } catch {
+    }
+  }
+
+  throw Object.assign(new Error(`spawn ${command} ENOENT`), {
+    code: 'ENOENT',
+    errno: 'ENOENT',
+    syscall: `spawn ${command}`,
+    path: command,
+  });
+}
+
+export function spawnCli(command: string, args: string[], options: SpawnOptions): ChildProcess {
+  if (process.platform === 'win32') {
+    return crossSpawn(resolveWindowsCommand(command, options), args, options);
+  }
+  return spawn(command, args, options);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "allowJs": true,
     "resolveJsonModule": true,
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

- replace the POSIX shell-based detached runner with a packaged Node.js runner
- resolve and launch Windows CLI executables and npm shims while preserving Unix/macOS lookup behavior
- harden startup failure handling, PID persistence, log handling, and Windows process-tree termination
- add regression coverage for Windows command discovery, detached execution, and MCP spawn failures

## Validation

- `npm.cmd run build`
- `npm.cmd run test:unit` — 294 tests passed
- Windows-focused suite — 104 tests passed
- live `acm-dev run` with `codex.cmd` completed successfully and the MCP server remained responsive

## Known test limitation

The broad default test command still includes legacy Bash-based fixtures that are not runnable on native Windows; the Windows-focused and unit configurations pass.
