### PR TITLE
feat: add GPT-6 Astra and update codex-ultra

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, fable, haiku)
-    - Codex (gpt-5.4, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2)
+    - Codex (gpt-6-astra, gpt-5.4, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2)
     - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
     - Forge (`forge`)
     - OpenCode (`opencode` と `oc-<provider/model>` ラッパー。例: `oc-openai/gpt-5.4`)
@@ -259,14 +259,14 @@ Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用�
 - `prompt_file` (string, 任意): プロンプトを含むファイルへのパス。`prompt` または `prompt_file` のいずれかが必須です。絶対パス、または `workFolder` からの相対パスが指定可能です。
 - `workFolder` (string, 必須): CLIを実行する作業ディレクトリ。絶対パスである必要があります。
 - **モデル (Models):**
-    - **Ultra エイリアス:** `claude-ultra` (`opus`、自動的に max effort に設定。Fable は選択しません), `codex-ultra` (`gpt-5.6-sol`、自動的に ultra reasoning に設定), `gemini-ultra`
+    - **Ultra エイリアス:** `claude-ultra` (`opus`、自動的に max effort に設定。Fable は選択しません), `codex-ultra` (`gpt-6-astra`、自動的に ultra reasoning に設定), `gemini-ultra`
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku`
       - `fable` は Claude Code の最新 Fable モデルを明示的に選択します。Fable には別料金の usage credits が必要な場合があり、`claude-ultra` から暗黙には選択されません。
-    - Codex: `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
+    - Codex: `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
     - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
     - Forge: `forge`
     - OpenCode: `opencode`（設定済みのデフォルトモデル）および `oc-openai/gpt-5.4` のような明示ラッパー
-- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high", "xhigh", "max"）。Codex では `model_reasoning_effort` を使います（基本値: "low", "medium", "high", "xhigh"。GPT-5.6 Sol/Terra は "max" と "ultra"、Luna は "max" にも対応）。Gemini、Forge、OpenCode では `reasoning_effort` はサポートしません。
+- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high", "xhigh", "max"）。Codex では `model_reasoning_effort` を使います（基本値: "low", "medium", "high", "xhigh"。GPT-6 Astra と GPT-5.6 Sol/Terra は "max" と "ultra"、GPT-5.6 Luna は "max" にも対応）。Gemini、Forge、OpenCode では `reasoning_effort` はサポートしません。
 - `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。Claude、Codex、Gemini、Forge、OpenCode でサポートされます。OpenCode は `--session` による in-place resume で再開し、`oc-<provider/model>` の明示指定と併用できます。
 
 ### `wait`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 - Execute Gemini CLI with automatic approval mode (using `-y`)
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
 - Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, fable, haiku), Codex (gpt-5.4, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, fable, haiku), Codex (gpt-6-astra, gpt-5.4, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -256,14 +256,14 @@ Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, Forge CLI, or OpenCod
 - `prompt_file` (string, optional): Path to a file containing the prompt. Either `prompt` or `prompt_file` is required. Can be absolute path or relative to `workFolder`.
 - `workFolder` (string, required): The working directory for the CLI execution. Must be an absolute path.
 **Models:**
-- **Ultra Aliases:** `claude-ultra` (`opus`, defaults to max effort and does not select Fable), `codex-ultra` (`gpt-5.6-sol`, defaults to ultra reasoning), `gemini-ultra`
+- **Ultra Aliases:** `claude-ultra` (`opus`, defaults to max effort and does not select Fable), `codex-ultra` (`gpt-6-astra`, defaults to ultra reasoning), `gemini-ultra`
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku`
   - `fable` explicitly selects Claude Code's latest Fable model. Fable may require separately billed usage credits and is never selected implicitly by `claude-ultra`.
-- Codex: `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
+- Codex: `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
 - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 - Forge: `forge`
 - OpenCode: `opencode` for the configured default backend model, plus explicit wrappers like `oc-openai/gpt-5.4`
-- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high", "xhigh", "max"). Codex uses `model_reasoning_effort` (base levels: "low", "medium", "high", "xhigh"; GPT-5.6 Sol/Terra also support "max" and "ultra", while Luna supports "max"). Gemini, Forge, and OpenCode do not support `reasoning_effort`.
+- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high", "xhigh", "max"). Codex uses `model_reasoning_effort` (base levels: "low", "medium", "high", "xhigh"; GPT-6 Astra and GPT-5.6 Sol/Terra also support "max" and "ultra", while GPT-5.6 Luna supports "max"). Gemini, Forge, and OpenCode do not support `reasoning_effort`.
 - `session_id` (string, optional): Optional session ID to resume a previous session. Supported for Claude, Codex, Gemini, Forge, and OpenCode. OpenCode resumes in place via `--session` and may also be combined with an explicit `oc-<provider/model>` selection.
 
 ### `wait`

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -122,7 +122,7 @@ src/
 
 ```
 claude-ultra  → opus (+ reasoning_effort: max)
-codex-ultra   → gpt-5.6-sol (+ reasoning_effort: ultra)
+codex-ultra   → gpt-6-astra (+ reasoning_effort: ultra)
 gemini-ultra  → gemini-3.1-pro-preview
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -146,7 +146,7 @@ This will open a web interface where you can:
 2. Test each tool with different parameters
 3. Test different AI models including:
    - Claude models: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku`
-   - Codex models: `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
+   - Codex models: `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
    - Gemini models: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 
 Example test: Select the `run` tool and provide:

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -108,7 +108,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 | Provider | Models |
 |---|---|
 | Claude | `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku` |
-| Codex | `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` |
+| Codex | `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` |
 | Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
 | Ultra aliases | `claude-ultra`, `codex-ultra`, `gemini-ultra` |
 

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -309,7 +309,7 @@ describe('ai-cli app', () => {
         }),
         expect.objectContaining({
           name: 'codex-ultra',
-          resolvesTo: 'gpt-5.6-sol',
+          resolvesTo: 'gpt-6-astra',
           agent: 'codex',
           defaultReasoningEffort: 'ultra',
         }),
@@ -318,6 +318,7 @@ describe('ai-cli app', () => {
     expect(payload.claude).toContain('sonnet');
     expect(payload.claude).toContain('fable');
     expect(payload.codex).not.toContain('codex');
+    expect(payload.codex).toContain('gpt-6-astra');
     expect(payload.codex).toContain('gpt-5.4');
     expect(payload.codex).toContain('gpt-5.6-sol');
     expect(payload.codex).toContain('gpt-5.6-terra');
@@ -412,7 +413,7 @@ describe('ai-cli app', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toHaveBeenCalledWith(RUN_HELP_TEXT);
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('claude-ultra'));
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.6-sol'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-6-astra'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gemini-2.5-pro'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('forge'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('opencode'));

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -38,8 +38,8 @@ describe('cli-builder', () => {
       expect(resolveModelAlias('claude-ultra')).toBe('opus');
     });
 
-    it('should resolve codex-ultra to gpt-5.6-sol', () => {
-      expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.6-sol');
+    it('should resolve codex-ultra to gpt-6-astra', () => {
+      expect(resolveModelAlias('codex-ultra')).toBe('gpt-6-astra');
     });
 
     it('should resolve gemini-ultra to gemini-3.1-pro-preview', () => {
@@ -79,6 +79,8 @@ describe('cli-builder', () => {
       expect(getReasoningEffort('gpt-5.2', 'medium')).toBe('medium');
       expect(getReasoningEffort('gpt-5.2', 'high')).toBe('high');
       expect(getReasoningEffort('gpt-5.2', 'xhigh')).toBe('xhigh');
+      expect(getReasoningEffort('gpt-6-astra', 'max')).toBe('max');
+      expect(getReasoningEffort('gpt-6-astra', 'ultra')).toBe('ultra');
       expect(getReasoningEffort('gpt-5.6-sol', 'max')).toBe('max');
       expect(getReasoningEffort('gpt-5.6-sol', 'ultra')).toBe('ultra');
       expect(getReasoningEffort('gpt-5.6-terra', 'ultra')).toBe('ultra');
@@ -412,7 +414,7 @@ describe('cli-builder', () => {
         expect(cmd.args).toContain('gpt-5.3-codex');
       });
 
-      it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+      it.each(['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
         'should build codex command for %s',
         (model) => {
           const cmd = buildCliCommand({
@@ -465,7 +467,8 @@ describe('cli-builder', () => {
         });
 
         expect(cmd.agent).toBe('codex');
-        expect(cmd.resolvedModel).toBe('gpt-5.6-sol');
+        expect(cmd.resolvedModel).toBe('gpt-6-astra');
+        expect(cmd.args[cmd.args.indexOf('--model') + 1]).toBe('gpt-6-astra');
         expect(cmd.args).toContain('-c');
         expect(cmd.args).toContain('model_reasoning_effort=ultra');
       });

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -117,6 +117,7 @@ describe('MCP Contract Tests', () => {
     expect(runTool.inputSchema.properties.model.description).toContain('opencode');
     expect(runTool.inputSchema.properties.model.description).toContain('oc-<provider/model>');
     expect(runTool.inputSchema.properties.model.description).toContain('auto ultra reasoning');
+    expect(runTool.inputSchema.properties.model.description).toContain('gpt-6-astra');
     expect(runTool.inputSchema.properties.reasoning_effort.description).toContain('"ultra"');
     expect(runTool.inputSchema.properties.reasoning_effort.description).toContain('OpenCode do not support reasoning_effort');
     expect(runTool.inputSchema.properties.session_id.description).toBe(
@@ -169,11 +170,18 @@ describe('MCP Contract Tests', () => {
           agent: 'claude',
           defaultReasoningEffort: 'max',
         }),
+        expect.objectContaining({
+          name: 'codex-ultra',
+          resolvesTo: 'gpt-6-astra',
+          agent: 'codex',
+          defaultReasoningEffort: 'ultra',
+        }),
       ])
     );
     expect(modelsData.claude).toContain('sonnet');
     expect(modelsData.claude).toContain('fable');
     expect(modelsData.codex).toEqual([
+      'gpt-6-astra',
       'gpt-5.4',
       'gpt-5.6-sol',
       'gpt-5.6-terra',

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -28,7 +28,7 @@ Options:
   --cwd <path>                 Working directory
   --prompt <text>              Prompt text
   --prompt-file <path>         Path to a prompt file
-  --model <model>              Model name or alias (e.g. sonnet, fable, claude-ultra, gpt-5.6-sol, codex-ultra, gemini-2.5-pro, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
+  --model <model>              Model name or alias (e.g. sonnet, fable, claude-ultra, gpt-6-astra, codex-ultra, gemini-2.5-pro, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
   --session-id <id>            Resume a previous session, including OpenCode in-place resumes
   --reasoning-effort <level>   Reasoning level for Claude/Codex only; unsupported for Gemini, Forge, and OpenCode
   --help, -h                   Show this help message

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -186,7 +186,7 @@ ${getSupportedModelsDescription()}
               },
               reasoning_effort: {
                 type: 'string',
-                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high", "xhigh", "max". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh"; GPT-5.6 Sol and Terra also support "max" and "ultra", while Luna supports "max". Gemini, Forge, and OpenCode do not support reasoning_effort in this integration.',
+                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high", "xhigh", "max". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh"; GPT-6 Astra and GPT-5.6 Sol/Terra also support "max" and "ultra", while GPT-5.6 Luna supports "max". Gemini, Forge, and OpenCode do not support reasoning_effort in this integration.',
               },
               session_id: {
                 type: 'string',

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -6,8 +6,8 @@ import { MODEL_ALIASES } from './model-catalog.js';
 export const ALLOWED_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
 const CLAUDE_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
 const CODEX_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
-const CODEX_MAX_REASONING_MODELS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
-const CODEX_ULTRA_REASONING_MODELS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra']);
+const CODEX_MAX_REASONING_MODELS = new Set(['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
+const CODEX_ULTRA_REASONING_MODELS = new Set(['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra']);
 const OPENCODE_MODEL_ERROR = 'Invalid OpenCode model. Expected exact syntax oc-<provider/model>.';
 
 type Agent = 'codex' | 'claude' | 'gemini' | 'forge' | 'opencode';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,12 +35,12 @@ function parseArgs(argv: string[]): Record<string, string> {
 const USAGE = `Usage: npm run -s cli.run -- --model <model> --workFolder <path> --prompt "..." [options]
 
 Options:
-  --model              Model name or alias (e.g. sonnet, opus, fable, gpt-5.6-sol, gemini-2.5-pro, forge, opencode, oc-openai/gpt-5.4)
+  --model              Model name or alias (e.g. sonnet, opus, fable, gpt-6-astra, gemini-2.5-pro, forge, opencode, oc-openai/gpt-5.4)
   --workFolder         Working directory (absolute path)
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt
   --session_id         Session ID to resume, including OpenCode in-place resumes
-  --reasoning_effort   Claude/Codex only: Claude=low|medium|high|xhigh|max, Codex=low|medium|high|xhigh (GPT-5.6: max; Sol/Terra: ultra); unsupported for Gemini, Forge, and OpenCode
+  --reasoning_effort   Claude/Codex only: Claude=low|medium|high|xhigh|max, Codex=low|medium|high|xhigh (GPT-6 Astra/GPT-5.6: max; Astra/Sol/Terra: ultra); unsupported for Gemini, Forge, and OpenCode
   --help               Show this help message
 
 Raw CLI output goes to stdout. Use cli.run.parse to parse the output:

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,5 +1,6 @@
 export const CLAUDE_MODELS = ['sonnet', 'sonnet[1m]', 'opus', 'opusplan', 'fable', 'haiku'] as const;
 export const CODEX_MODELS = [
+  'gpt-6-astra',
   'gpt-5.4',
   'gpt-5.6-sol',
   'gpt-5.6-terra',
@@ -22,13 +23,13 @@ export const OPENCODE_MODELS = ['opencode'] as const;
 
 export const MODEL_ALIASES: Record<string, string> = {
   'claude-ultra': 'opus',
-  'codex-ultra': 'gpt-5.6-sol',
+  'codex-ultra': 'gpt-6-astra',
   'gemini-ultra': 'gemini-3.1-pro-preview',
 };
 
 export const MODEL_ALIAS_DETAILS = [
   { name: 'claude-ultra', resolvesTo: 'opus', agent: 'claude', defaultReasoningEffort: 'max' },
-  { name: 'codex-ultra', resolvesTo: 'gpt-5.6-sol', agent: 'codex', defaultReasoningEffort: 'ultra' },
+  { name: 'codex-ultra', resolvesTo: 'gpt-6-astra', agent: 'codex', defaultReasoningEffort: 'ultra' },
   { name: 'gemini-ultra', resolvesTo: 'gemini-3.1-pro-preview', agent: 'gemini' },
 ] as const;
 


### PR DESCRIPTION
## Summary

`codex-ultra` currently selects `gpt-5.6-sol`. Update it to select `gpt-6-astra` while retaining the default `ultra` reasoning effort, and allow Astra to be selected directly through the CLI and MCP.

## Type of Change

- [x] feat: New feature
- [x] docs: Documentation
- [x] test: Add or update tests

## Changes

- Add `gpt-6-astra` to the shared model catalog and update the `codex-ultra` alias and discovery metadata.
- Accept Astra's `max` and `ultra` reasoning settings in the Codex CLI argument builder.
- Update CLI help, MCP descriptions, English/Japanese documentation, and regression coverage for model discovery, alias resolution, and generated CLI arguments.

## Test Plan

- [x] `npm run test:release` passes: 305 tests passed and 15 skipped in the main suite; 2 live-test configuration checks and 4 package checks passed. The opt-in full live suite was not enabled by this command.
- [x] Targeted CLI builder, CLI interface, and MCP contract tests: 93 passed.
- [x] Live `acm-dev` MCP smoke test on Codex CLI 0.153.4: `codex-ultra` completed with exit code 0 and returned `ASTRA_SMOKE_OK 17*19=323`.
- [ ] Full release-time live E2E across Claude and Codex (not run; the targeted Astra MCP smoke test above was run).

## Notes

The tested Codex CLI version is 0.153.4. Version 0.150.1 was rejected by the service with an error requiring a newer Codex version for `gpt-6-astra`.
