### PR TITLE
feat(gemini): add the Antigravity CLI as an opt-in Gemini backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,9 @@ Then use `ai-cli-mcp` command globally.
 |----------|-------------|
 | `CLAUDE_CLI_NAME` | Claude CLI binary name or absolute path |
 | `CODEX_CLI_NAME` | Codex CLI binary name or absolute path |
-| `GEMINI_CLI_NAME` | Gemini CLI binary name or absolute path |
+| `GEMINI_CLI_NAME` | Gemini CLI binary name or absolute path (default: `gemini`, or `agy` when `GEMINI_CLI_BACKEND=antigravity`) |
+| `GEMINI_CLI_BACKEND` | CLI that serves the `gemini` agent: `gemini-cli` (default), `antigravity`, or `auto` |
+| `GEMINI_PRINT_TIMEOUT` | Antigravity backend only: value passed to `agy --print-timeout` (default: `2h`) |
 | `MCP_CLAUDE_DEBUG` | Enable debug logging (`true`/`false`) |
 
 ## Release Process

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,13 +19,13 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 
 - すべての権限確認をスキップしてClaude CLIを実行（`--dangerously-skip-permissions` を使用）
 - 承認とサンドボックスをバイパスしてCodex CLIを実行（`--dangerously-bypass-approvals-and-sandbox` を使用）
-- 自動承認モードでGemini CLIを実行（`-y` を使用）
+- 自動承認モードでGemini CLIを実行（`-y` を使用）。`GEMINI_CLI_BACKEND=antigravity` を設定すると、`gemini` エージェントを Antigravity CLI（`agy`）で動かすこともできます
 - Forge CLI を非対話モードで実行（`forge -C <workFolder> -p <prompt>` を使用）
 - OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, fable, haiku)
     - Codex (gpt-6-astra, gpt-5.4, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2)
-    - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
+    - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview。`GEMINI_CLI_BACKEND=antigravity` を設定すると Antigravity 用の別カタログを使用)
     - Forge (`forge`)
     - OpenCode (`opencode` と `oc-<provider/model>` ラッパー。例: `oc-openai/gpt-5.4`)
 - PID追跡によるバックグラウンドプロセスの管理
@@ -170,6 +170,23 @@ codex login
 gemini auth login
 ```
 
+### Antigravity CLIの場合（Gemini バックエンドの任意選択）:
+
+`gemini` エージェントは既定で Gemini CLI を使用します。代わりに Antigravity CLI を
+使いたい場合は、公式の `agy` バイナリをインストールしてログインし、
+`GEMINI_CLI_BACKEND=antigravity` を設定してください。
+
+```bash
+# 公式の Antigravity CLI をインストールしてから:
+agy login
+export GEMINI_CLI_BACKEND=antigravity
+```
+
+この環境変数を設定しない限り挙動は一切変わりません。既定値は `gemini-cli`、既定の
+バイナリは `gemini` のままで、`ai-cli doctor` が `agy` を探すのは Antigravity
+バックエンドを選択したときだけです。詳細は
+[Gemini バックエンド](#gemini-バックエンド) を参照してください。
+
 macOSでは、これらのツールを初めて実行する際にフォルダへのアクセス許可を求められる場合があります。最初の実行が失敗しても、2回目以降は動作するはずです。
 
 ## CLI コマンド
@@ -263,10 +280,11 @@ Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用�
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku`
       - `fable` は Claude Code の最新 Fable モデルを明示的に選択します。Fable には別料金の usage credits が必要な場合があり、`claude-ultra` から暗黙には選択されません。
     - Codex: `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
-    - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+    - Gemini（既定の `gemini-cli` バックエンド）: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+    - Gemini（`antigravity` バックエンド）: `Gemini 3.8 Flash (High|Medium|Low)`, `Gemini 3.7 Flash (High|Medium|Low)`, `Gemini 3.6 Flash (High|Medium|Low)`, `Gemini 3.1 Pro (High|Low)`。加えて `gemini-3.8-flash-high`, `gemini-3.8-flash`, `gemini-3.8-flash-low` などの小文字エイリアス（3.7 / 3.6 / 3.1 も同様）が使えます。もう一方のバックエンドのモデルを指定した場合は、必要な `GEMINI_CLI_BACKEND` の値を示す明示的なエラーになります。
     - Forge: `forge`
     - OpenCode: `opencode`（設定済みのデフォルトモデル）および `oc-openai/gpt-5.4` のような明示ラッパー
-- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high", "xhigh", "max"）。Codex では `model_reasoning_effort` を使います（基本値: "low", "medium", "high", "xhigh"。GPT-6 Astra と GPT-5.6 Sol/Terra は "max" と "ultra"、GPT-5.6 Luna は "max" にも対応）。Gemini、Forge、OpenCode では `reasoning_effort` はサポートしません。
+- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high", "xhigh", "max"）。Codex では `model_reasoning_effort` を使います（基本値: "low", "medium", "high", "xhigh"。GPT-6 Astra と GPT-5.6 Sol/Terra は "max" と "ultra"、GPT-5.6 Luna は "max" にも対応）。Forge と OpenCode では `reasoning_effort` はサポートしません。Gemini も既定の `gemini-cli` バックエンドではサポートしませんが、`antigravity` バックエンドでは "low", "medium", "high" を受け付け、対応するモデル variant を選択します（例: `gemini-3.8-flash` に `reasoning_effort: "high"` を指定すると `Gemini 3.8 Flash (High)` を実行）。Gemini 3.1 Pro は "low" と "high" のみです。
 - `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。Claude、Codex、Gemini、Forge、OpenCode でサポートされます。OpenCode は `--session` による in-place resume で再開し、`oc-<provider/model>` の明示指定と併用できます。
 
 ### `wait`
@@ -409,13 +427,35 @@ ACM_LIVE_E2E=1 ACM_LIVE_E2E_SURFACE=all ACM_LIVE_E2E_AGENTS=claude,codex npm run
 
 live E2E は opt-in です。インストール済みかつ認証済みの外部 CLI、ネットワーク、provider 側の可用性、コスト予算に依存するため、通常の `npm test` には含めていません。`ACM_LIVE_E2E_SURFACE` は既定で `cli` です。MCP server surface も含める場合は `mcp` または `all` を指定します。
 
+## Gemini バックエンド
+
+`gemini` エージェントは2種類のCLIで動かせます。どちらを使うかは
+`GEMINI_CLI_BACKEND` で選択し、既定値は従来の挙動をそのまま維持します。
+
+| 値 | 挙動 |
+| --- | --- |
+| `gemini-cli`（デフォルト） | 従来どおりの Gemini CLI。バイナリ `gemini`、引数 `-y --output-format stream-json`、`gemini-2.5-*` / `gemini-3-*` カタログ。 |
+| `antigravity` | Antigravity CLI。バイナリ `agy`、引数 `--dangerously-skip-permissions --print-timeout <timeout> [--log-file <path>] [--conversation <id>] --model "<name>" -p <prompt>`、`Gemini 3.x` 表示名カタログ。 |
+| `auto` | 解決された Gemini コマンドが `agy`（または `agy-*`）なら Antigravity、それ以外は Gemini CLI。 |
+
+Antigravity バックエンドの注意点:
+
+- 推論レベルはモデル名の一部なので、`reasoning_effort` はCLIフラグではなく対応する
+  カタログ variant の選択になります。
+- `agy` は stream JSON ではなくプレーンテキストを出力します。セッション再開に使う
+  conversation id は、アダプタが `--log-file` で渡す一時ログファイルから読み取ります。
+- `--print-timeout` の既定値は `2h` で、`GEMINI_PRINT_TIMEOUT` で上書きできます。
+- `models` ツールは両方のカタログと、現在有効なバックエンドを返します。
+
 ## 高度な設定（オプション）
 
 通常の利用では設定不要ですが、CLIツールのパスをカスタマイズしたい場合やデバッグが必要な場合に使用できる環境変数です。
 
 - `CLAUDE_CLI_NAME`: Claude CLIのバイナリ名または絶対パスを上書き（デフォルト: `claude`）
 - `CODEX_CLI_NAME`: Codex CLIのバイナリ名または絶対パスを上書き（デフォルト: `codex`）
-- `GEMINI_CLI_NAME`: Gemini CLIのバイナリ名または絶対パスを上書き（デフォルト: `gemini`）
+- `GEMINI_CLI_NAME`: Gemini CLIのバイナリ名または絶対パスを上書き（デフォルト: `gemini`。`GEMINI_CLI_BACKEND=antigravity` の場合は `agy`）
+- `GEMINI_CLI_BACKEND`: `gemini` エージェントを動かすCLIの選択: `gemini-cli`（デフォルト）、`antigravity`、`auto`。未知の値はエラーになります
+- `GEMINI_PRINT_TIMEOUT`: Antigravity バックエンド専用。`agy --print-timeout` に渡す値（デフォルト: `2h`）
 - `FORGE_CLI_NAME`: Forge CLIのバイナリ名または絶対パスを上書き（デフォルト: `forge`）
 - `OPENCODE_CLI_NAME`: OpenCode CLIのバイナリ名または絶対パスを上書き（デフォルト: `opencode`）
 - `MCP_CLAUDE_DEBUG`: デバッグログを有効化（`true` に設定すると詳細な出力が表示されます）

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 
 - Run Claude CLI with all permissions bypassed (using `--dangerously-skip-permissions`)
 - Execute Codex CLI with approvals and sandbox bypassed (using `--dangerously-bypass-approvals-and-sandbox`)
-- Execute Gemini CLI with automatic approval mode (using `-y`)
+- Execute Gemini CLI with automatic approval mode (using `-y`), or optionally serve the `gemini` agent with the Antigravity CLI (`agy`) by setting `GEMINI_CLI_BACKEND=antigravity`
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
 - Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, fable, haiku), Codex (gpt-6-astra, gpt-5.4, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, fable, haiku), Codex (gpt-6-astra, gpt-5.4, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview; a separate Antigravity catalog is available with `GEMINI_CLI_BACKEND=antigravity`), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -167,6 +167,23 @@ codex login
 gemini auth login
 ```
 
+### For the Antigravity CLI (optional Gemini backend):
+
+The `gemini` agent runs on the Gemini CLI by default. If you would rather serve it
+with the Antigravity CLI, install the official `agy` binary, sign in once, and set
+`GEMINI_CLI_BACKEND=antigravity`:
+
+```bash
+# Install the official Antigravity CLI, then:
+agy login
+export GEMINI_CLI_BACKEND=antigravity
+```
+
+Nothing changes for anyone who does not set the variable: the default is
+`gemini-cli`, the default binary stays `gemini`, and `ai-cli doctor` only looks for
+`agy` once the Antigravity backend is selected. See
+[Gemini backends](#gemini-backends) for the model catalog and options.
+
 macOS might ask for folder permissions the first time any of these tools run. If the first run fails, subsequent runs should work.
 
 ## CLI Commands
@@ -260,10 +277,11 @@ Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, Forge CLI, or OpenCod
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku`
   - `fable` explicitly selects Claude Code's latest Fable model. Fable may require separately billed usage credits and is never selected implicitly by `claude-ultra`.
 - Codex: `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
-- Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+- Gemini (default `gemini-cli` backend): `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+- Gemini (`antigravity` backend): `Gemini 3.8 Flash (High|Medium|Low)`, `Gemini 3.7 Flash (High|Medium|Low)`, `Gemini 3.6 Flash (High|Medium|Low)`, `Gemini 3.1 Pro (High|Low)`, plus the lowercase aliases `gemini-3.8-flash-high`, `gemini-3.8-flash`, `gemini-3.8-flash-low` and their 3.7 / 3.6 / 3.1 equivalents. Requesting a model from the other backend fails with an explicit error naming the `GEMINI_CLI_BACKEND` value it needs.
 - Forge: `forge`
 - OpenCode: `opencode` for the configured default backend model, plus explicit wrappers like `oc-openai/gpt-5.4`
-- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high", "xhigh", "max"). Codex uses `model_reasoning_effort` (base levels: "low", "medium", "high", "xhigh"; GPT-6 Astra and GPT-5.6 Sol/Terra also support "max" and "ultra", while GPT-5.6 Luna supports "max"). Gemini, Forge, and OpenCode do not support `reasoning_effort`.
+- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high", "xhigh", "max"). Codex uses `model_reasoning_effort` (base levels: "low", "medium", "high", "xhigh"; GPT-6 Astra and GPT-5.6 Sol/Terra also support "max" and "ultra", while GPT-5.6 Luna supports "max"). Forge and OpenCode do not support `reasoning_effort`, and neither does Gemini on the default `gemini-cli` backend. On the `antigravity` backend Gemini accepts "low", "medium", "high" and selects the matching model variant (e.g. `gemini-3.8-flash` with `reasoning_effort: "high"` runs `Gemini 3.8 Flash (High)`); Gemini 3.1 Pro only publishes "low" and "high".
 - `session_id` (string, optional): Optional session ID to resume a previous session. Supported for Claude, Codex, Gemini, Forge, and OpenCode. OpenCode resumes in place via `--session` and may also be combined with an explicit `oc-<provider/model>` selection.
 
 ### `wait`
@@ -399,13 +417,36 @@ ACM_LIVE_E2E=1 ACM_LIVE_E2E_SURFACE=all ACM_LIVE_E2E_AGENTS=claude,codex npm run
 
 Live E2E is opt-in because it depends on installed and authenticated external CLIs, network access, provider availability, and cost budget. `ACM_LIVE_E2E_SURFACE` defaults to `cli`; use `mcp` or `all` to include the MCP server surface.
 
+## Gemini backends
+
+The `gemini` agent can be served by two different CLIs. `GEMINI_CLI_BACKEND` picks
+which one, and the default keeps the historical behavior unchanged.
+
+| Value | Behavior |
+| --- | --- |
+| `gemini-cli` (default) | Gemini CLI, exactly as before: binary `gemini`, arguments `-y --output-format stream-json`, and the `gemini-2.5-*` / `gemini-3-*` catalog. |
+| `antigravity` | Antigravity CLI: binary `agy`, arguments `--dangerously-skip-permissions --print-timeout <timeout> [--log-file <path>] [--conversation <id>] --model "<name>" -p <prompt>`, and the `Gemini 3.x` display-name catalog. |
+| `auto` | Antigravity when the resolved Gemini command is `agy` (or `agy-*`), otherwise the Gemini CLI. |
+
+Notes on the Antigravity backend:
+
+- The reasoning level is part of the model name, so `reasoning_effort` selects the
+  matching catalog variant instead of passing a CLI flag.
+- `agy` prints plain text rather than stream JSON, and its conversation id (used to
+  resume a session) is read back from a temporary log file the adapter passes with
+  `--log-file`.
+- `--print-timeout` defaults to `2h` and can be overridden with `GEMINI_PRINT_TIMEOUT`.
+- The `models` tool reports both catalogs and which backend is active.
+
 ## Advanced Configuration (Optional)
 
 Normally not required, but useful for customizing CLI paths or debugging.
 
 - `CLAUDE_CLI_NAME`: Override the Claude CLI binary name or provide an absolute path (default: `claude`)
 - `CODEX_CLI_NAME`: Override the Codex CLI binary name or provide an absolute path (default: `codex`)
-- `GEMINI_CLI_NAME`: Override the Gemini CLI binary name or provide an absolute path (default: `gemini`)
+- `GEMINI_CLI_NAME`: Override the Gemini CLI binary name or provide an absolute path (default: `gemini`, or `agy` when `GEMINI_CLI_BACKEND=antigravity`)
+- `GEMINI_CLI_BACKEND`: Which CLI serves the `gemini` agent: `gemini-cli` (default), `antigravity`, or `auto`. An unknown value is rejected with an error.
+- `GEMINI_PRINT_TIMEOUT`: Antigravity backend only. Value passed to `agy --print-timeout` (default: `2h`)
 - `FORGE_CLI_NAME`: Override the Forge CLI binary name or provide an absolute path (default: `forge`)
 - `OPENCODE_CLI_NAME`: Override the OpenCode CLI binary name or provide an absolute path (default: `opencode`)
 - `MCP_CLAUDE_DEBUG`: Enable debug logging (set to `true` for verbose output)

--- a/docs/development.md
+++ b/docs/development.md
@@ -147,7 +147,8 @@ This will open a web interface where you can:
 3. Test different AI models including:
    - Claude models: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku`
    - Codex models: `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
-   - Gemini models: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+   - Gemini models (default `gemini-cli` backend): `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+   - Gemini models (`GEMINI_CLI_BACKEND=antigravity`): `Gemini 3.8 Flash (High|Medium|Low)`, `Gemini 3.7 Flash (High|Medium|Low)`, `Gemini 3.6 Flash (High|Medium|Low)`, `Gemini 3.1 Pro (High|Low)`
 
 Example test: Select the `run` tool and provide:
 - `prompt`: "What is 2+2?"
@@ -160,7 +161,9 @@ Example test: Select the `run` tool and provide:
 |----------|-------------|
 | `CLAUDE_CLI_NAME` | Claude CLI binary name or absolute path (default: `claude`) |
 | `CODEX_CLI_NAME` | Codex CLI binary name or absolute path (default: `codex`) |
-| `GEMINI_CLI_NAME` | Gemini CLI binary name or absolute path (default: `gemini`) |
+| `GEMINI_CLI_NAME` | Gemini CLI binary name or absolute path (default: `gemini`, or `agy` when `GEMINI_CLI_BACKEND=antigravity`) |
+| `GEMINI_CLI_BACKEND` | CLI that serves the `gemini` agent — `gemini-cli` (default), `antigravity`, or `auto` |
+| `GEMINI_PRINT_TIMEOUT` | Antigravity backend only: value passed to `agy --print-timeout` (default: `2h`) |
 | `MCP_CLAUDE_DEBUG` | Enable debug logging — `true` / `false` (default: `false`) |
 
 These can be set in your shell environment or within the `env` block of your `mcp.json` server configuration.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -109,7 +109,8 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 |---|---|
 | Claude | `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `fable`, `haiku` |
 | Codex | `gpt-6-astra`, `gpt-5.4`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` |
-| Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
+| Gemini (`gemini-cli` backend, default) | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
+| Gemini (`antigravity` backend) | `Gemini 3.8 Flash (High\|Medium\|Low)`, `Gemini 3.7 Flash (High\|Medium\|Low)`, `Gemini 3.6 Flash (High\|Medium\|Low)`, `Gemini 3.1 Pro (High\|Low)` |
 | Ultra aliases | `claude-ultra`, `codex-ultra`, `gemini-ultra` |
 
 ## User Scenarios

--- a/docs/session-stacking.md
+++ b/docs/session-stacking.md
@@ -63,5 +63,6 @@ run("洗い出した問題を修正して", session_id="def-456", model="sonnet"
 | CLI | 内部で実行されるフラグ |
 |---|---|
 | Claude | `-r <session_id> --fork-session` |
-| Gemini | `-r <session_id>` |
+| Gemini (`gemini-cli` バックエンド、既定) | `-r <session_id>` |
+| Gemini (`GEMINI_CLI_BACKEND=antigravity`) | `--conversation <session_id>` |
 | Codex | `exec resume <session_id>` |

--- a/src/__tests__/gemini-antigravity.test.ts
+++ b/src/__tests__/gemini-antigravity.test.ts
@@ -1,0 +1,492 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { CliProcessService } from '../cli-process-service.js';
+import { buildCliCommand, getReasoningEffort, resolveModelAlias } from '../cli-builder.js';
+import {
+  ANTIGRAVITY_GEMINI_MODELS,
+  ANTIGRAVITY_MODEL_ALIASES,
+  GEMINI_MODELS,
+  getGeminiModelsForBackend,
+  getModelsPayload,
+  getRequiredGeminiBackendForModel,
+  MODEL_ALIASES,
+} from '../model-catalog.js';
+import { parseAntigravityOutput, parseGeminiOutput, PeekEventExtractor, PeekMessageExtractor } from '../parsers.js';
+
+const CLI_PATHS = {
+  claude: '/usr/bin/claude',
+  codex: '/usr/bin/codex',
+  gemini: '/usr/bin/gemini',
+  forge: '/usr/bin/forge',
+  opencode: '/usr/bin/opencode',
+};
+
+const ANTIGRAVITY_CLI_PATHS = { ...CLI_PATHS, gemini: '/usr/local/bin/agy' };
+
+function build(overrides: Record<string, any> = {}) {
+  return buildCliCommand({
+    prompt: 'hello',
+    workFolder: process.cwd(),
+    cliPaths: CLI_PATHS,
+    ...overrides,
+  } as any);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('gemini backend selection in buildCliCommand', () => {
+  it('keeps the Gemini CLI arguments untouched when no backend is configured', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', '');
+    const cmd = build({ model: 'gemini-2.5-pro', session_id: 'abc' });
+
+    expect(cmd.agent).toBe('gemini');
+    expect(cmd.geminiBackend).toBe('gemini-cli');
+    expect(cmd.cliPath).toBe('/usr/bin/gemini');
+    expect(cmd.args).toEqual([
+      '-y',
+      '--output-format',
+      'stream-json',
+      '-r',
+      'abc',
+      '--model',
+      'gemini-2.5-pro',
+      'hello',
+    ]);
+  });
+
+  it('builds Antigravity arguments when the backend is selected', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    const cmd = build({
+      model: 'gemini-3.8-flash-high',
+      session_id: 'conv-1',
+      log_file: '/tmp/agy.log',
+      cliPaths: ANTIGRAVITY_CLI_PATHS,
+    });
+
+    expect(cmd.agent).toBe('gemini');
+    expect(cmd.geminiBackend).toBe('antigravity');
+    expect(cmd.cliPath).toBe('/usr/local/bin/agy');
+    expect(cmd.args).toEqual([
+      '--dangerously-skip-permissions',
+      '--print-timeout',
+      '2h',
+      '--log-file',
+      '/tmp/agy.log',
+      '--conversation',
+      'conv-1',
+      '--model',
+      'Gemini 3.8 Flash (High)',
+      '-p',
+      'hello',
+    ]);
+    expect(cmd.resolvedModel).toBe('Gemini 3.8 Flash (High)');
+  });
+
+  it('omits --log-file and --conversation when they are not provided', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    const cmd = build({ model: 'gemini-3.6-flash', cliPaths: ANTIGRAVITY_CLI_PATHS });
+
+    expect(cmd.args).toEqual([
+      '--dangerously-skip-permissions',
+      '--print-timeout',
+      '2h',
+      '--model',
+      'Gemini 3.6 Flash (Medium)',
+      '-p',
+      'hello',
+    ]);
+  });
+
+  it('selects Antigravity in auto mode only when the resolved binary is agy', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'auto');
+
+    const antigravity = build({ model: 'gemini-3.7-flash-low', cliPaths: ANTIGRAVITY_CLI_PATHS });
+    expect(antigravity.geminiBackend).toBe('antigravity');
+    expect(antigravity.args).toContain('--dangerously-skip-permissions');
+
+    const geminiCli = build({ model: 'gemini-2.5-flash' });
+    expect(geminiCli.geminiBackend).toBe('gemini-cli');
+    expect(geminiCli.args).toContain('--output-format');
+  });
+
+  it('fails loudly on an unknown GEMINI_CLI_BACKEND value', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravty');
+    expect(() => build({ model: 'gemini-2.5-pro' })).toThrow(
+      'Invalid GEMINI_CLI_BACKEND: antigravty. Allowed values: gemini-cli, antigravity, auto.'
+    );
+  });
+
+  it('reads the print timeout from GEMINI_PRINT_TIMEOUT and from the build option', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    vi.stubEnv('GEMINI_PRINT_TIMEOUT', '45m');
+
+    const fromEnv = build({ model: 'gemini-3.8-flash', cliPaths: ANTIGRAVITY_CLI_PATHS });
+    expect(fromEnv.args).toEqual(expect.arrayContaining(['--print-timeout', '45m']));
+
+    const fromOption = build({
+      model: 'gemini-3.8-flash',
+      cliPaths: ANTIGRAVITY_CLI_PATHS,
+      antigravityPrintTimeout: '10m',
+    });
+    expect(fromOption.args).toEqual(expect.arrayContaining(['--print-timeout', '10m']));
+  });
+
+  it('accepts an Antigravity display name directly', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    const cmd = build({ model: 'Gemini 3.1 Pro (Low)', cliPaths: ANTIGRAVITY_CLI_PATHS });
+
+    expect(cmd.agent).toBe('gemini');
+    expect(cmd.args).toEqual(expect.arrayContaining(['--model', 'Gemini 3.1 Pro (Low)']));
+  });
+
+  it('leaves the other agents untouched under the Antigravity backend', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    const cmd = build({ model: 'sonnet', cliPaths: ANTIGRAVITY_CLI_PATHS });
+
+    expect(cmd.agent).toBe('claude');
+    expect(cmd.geminiBackend).toBeNull();
+  });
+});
+
+describe('per-backend gemini catalog', () => {
+  it('keeps the Gemini CLI catalog exactly as it is', () => {
+    expect([...GEMINI_MODELS]).toEqual([
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
+      'gemini-3.1-pro-preview',
+      'gemini-3-pro-preview',
+      'gemini-3-flash-preview',
+    ]);
+    expect(getGeminiModelsForBackend()).toBe(GEMINI_MODELS);
+    expect(getGeminiModelsForBackend('gemini-cli')).toBe(GEMINI_MODELS);
+  });
+
+  it('publishes the Antigravity catalog separately', () => {
+    expect(getGeminiModelsForBackend('antigravity')).toBe(ANTIGRAVITY_GEMINI_MODELS);
+    expect([...ANTIGRAVITY_GEMINI_MODELS]).toEqual([
+      'Gemini 3.8 Flash (High)',
+      'Gemini 3.8 Flash (Medium)',
+      'Gemini 3.8 Flash (Low)',
+      'Gemini 3.7 Flash (High)',
+      'Gemini 3.7 Flash (Medium)',
+      'Gemini 3.7 Flash (Low)',
+      'Gemini 3.6 Flash (High)',
+      'Gemini 3.6 Flash (Medium)',
+      'Gemini 3.6 Flash (Low)',
+      'Gemini 3.1 Pro (High)',
+      'Gemini 3.1 Pro (Low)',
+    ]);
+  });
+
+  it('adds Antigravity aliases without colliding with the legacy catalog', () => {
+    const legacyNames = new Set<string>([...GEMINI_MODELS, ...Object.keys(MODEL_ALIASES)]);
+    const collisions = Object.keys(ANTIGRAVITY_MODEL_ALIASES)
+      .filter((alias) => legacyNames.has(alias) && alias !== 'gemini-ultra');
+
+    expect(collisions).toEqual([]);
+    expect(Object.keys(ANTIGRAVITY_MODEL_ALIASES)).toEqual(expect.arrayContaining([
+      'gemini-3.8-flash-high',
+      'gemini-3.8-flash',
+      'gemini-3.8-flash-low',
+      'gemini-3.7-flash-high',
+      'gemini-3.7-flash',
+      'gemini-3.7-flash-low',
+      'gemini-3.6-flash-high',
+      'gemini-3.6-flash',
+      'gemini-3.6-flash-low',
+      'gemini-3.1-pro',
+      'gemini-3.1-pro-low',
+    ]));
+  });
+
+  it('resolves gemini-ultra per backend', () => {
+    expect(resolveModelAlias('gemini-ultra')).toBe('gemini-3.1-pro-preview');
+    expect(resolveModelAlias('gemini-ultra', 'gemini-cli')).toBe('gemini-3.1-pro-preview');
+    expect(resolveModelAlias('gemini-ultra', 'antigravity')).toBe('Gemini 3.1 Pro (High)');
+  });
+
+  it('reports the backend a model requires', () => {
+    expect(getRequiredGeminiBackendForModel('gemini-2.5-pro')).toBe('gemini-cli');
+    expect(getRequiredGeminiBackendForModel('gemini-3.8-flash-high')).toBe('antigravity');
+    expect(getRequiredGeminiBackendForModel('Gemini 3.8 Flash (High)')).toBe('antigravity');
+    expect(getRequiredGeminiBackendForModel('gemini-ultra')).toBeNull();
+    expect(getRequiredGeminiBackendForModel('gemini-experimental')).toBeNull();
+  });
+});
+
+describe('cross-backend model rejection', () => {
+  it('rejects an Antigravity model while the Gemini CLI backend is active', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'gemini-cli');
+    expect(() => build({ model: 'gemini-3.8-flash-high' })).toThrow(
+      'Model "gemini-3.8-flash-high" belongs to the antigravity Gemini backend and requires GEMINI_CLI_BACKEND=antigravity. The active Gemini backend is gemini-cli.'
+    );
+    expect(() => build({ model: 'Gemini 3.1 Pro (High)' })).toThrow(
+      /requires GEMINI_CLI_BACKEND=antigravity/
+    );
+  });
+
+  it('rejects a Gemini CLI model while the Antigravity backend is active', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    expect(() => build({ model: 'gemini-2.5-pro', cliPaths: ANTIGRAVITY_CLI_PATHS })).toThrow(
+      'Model "gemini-2.5-pro" belongs to the gemini-cli Gemini backend and requires GEMINI_CLI_BACKEND=gemini-cli. The active Gemini backend is antigravity.'
+    );
+    expect(() => build({ model: 'gemini-ultra', cliPaths: ANTIGRAVITY_CLI_PATHS })).not.toThrow();
+  });
+});
+
+describe('reasoning_effort for the gemini agent', () => {
+  it('stays unsupported on the Gemini CLI backend', () => {
+    expect(() => getReasoningEffort('gemini-2.5-pro', 'high')).toThrow(
+      'reasoning_effort is only supported for Claude and Codex models.'
+    );
+    expect(() => getReasoningEffort('gemini-2.5-pro', 'high', 'gemini-cli')).toThrow(
+      'reasoning_effort is only supported for Claude and Codex models.'
+    );
+
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'gemini-cli');
+    expect(() => build({ model: 'gemini-2.5-pro', reasoning_effort: 'high' })).toThrow(
+      'reasoning_effort is only supported for Claude and Codex models.'
+    );
+  });
+
+  it('selects the matching model variant on the Antigravity backend', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+
+    for (const [effort, expected] of [
+      ['low', 'Gemini 3.8 Flash (Low)'],
+      ['medium', 'Gemini 3.8 Flash (Medium)'],
+      ['high', 'Gemini 3.8 Flash (High)'],
+    ] as const) {
+      const cmd = build({
+        model: 'gemini-3.8-flash',
+        reasoning_effort: effort,
+        cliPaths: ANTIGRAVITY_CLI_PATHS,
+      });
+      expect(cmd.resolvedModel).toBe(expected);
+      expect(cmd.args).toEqual(expect.arrayContaining(['--model', expected]));
+      // The level lives in the model name, never in an --effort flag.
+      expect(cmd.args).not.toContain('--effort');
+    }
+  });
+
+  it('overrides the level already encoded in the requested model', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    const cmd = build({
+      model: 'gemini-3.7-flash-low',
+      reasoning_effort: 'high',
+      cliPaths: ANTIGRAVITY_CLI_PATHS,
+    });
+
+    expect(cmd.resolvedModel).toBe('Gemini 3.7 Flash (High)');
+  });
+
+  it('rejects a level the CLI does not define', () => {
+    expect(() => getReasoningEffort('gemini-3.8-flash', 'ultra', 'antigravity')).toThrow(
+      'Gemini reasoning_effort supports only low, medium, high.'
+    );
+  });
+
+  it('rejects a level the model family does not publish', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    expect(() => build({
+      model: 'gemini-3.1-pro',
+      reasoning_effort: 'medium',
+      cliPaths: ANTIGRAVITY_CLI_PATHS,
+    })).toThrow('Gemini reasoning_effort for Gemini 3.1 Pro supports only high, low.');
+  });
+});
+
+describe('output parsing per backend', () => {
+  it('keeps parsing Gemini CLI stream-json output', () => {
+    const output = [
+      '{"type":"init","timestamp":"2026-04-11T14:44:42.293Z","session_id":"gemini-session","model":"gemini-3.1-pro-preview"}',
+      '{"type":"message","role":"assistant","content":"Hello","delta":true}',
+      '{"type":"result","stats":{"tokens":7}}',
+    ].join('\n');
+
+    expect(parseGeminiOutput(output)).toEqual({
+      message: 'Hello',
+      session_id: 'gemini-session',
+      stats: { tokens: 7 },
+      tools: undefined,
+    });
+  });
+
+  it('parses Antigravity plain text plus the conversation id from the log file', () => {
+    const log = [
+      'I0606 11:20:31.000000 main.go:1] Starting agy',
+      'I0606 11:20:32.000000 conv.go:9] Created conversation conv-abc123',
+    ].join('\n');
+
+    expect(parseAntigravityOutput('The answer is 42.\n', log)).toEqual({
+      message: 'The answer is 42.',
+      session_id: 'conv-abc123',
+    });
+  });
+
+  it('recognizes the alternative conversation id log formats', () => {
+    expect(parseAntigravityOutput('ok', 'Print mode: conversation=conv-xyz')).toEqual({
+      message: 'ok',
+      session_id: 'conv-xyz',
+    });
+    expect(parseAntigravityOutput('ok', 'starting conversationID="conv-quoted"')).toEqual({
+      message: 'ok',
+      session_id: 'conv-quoted',
+    });
+  });
+
+  it('returns the message without a session id when the log has none', () => {
+    expect(parseAntigravityOutput('plain answer', '')).toEqual({
+      message: 'plain answer',
+      session_id: null,
+    });
+    expect(parseAntigravityOutput('', '')).toBeNull();
+    expect(parseAntigravityOutput('', 'Created conversation conv-only')).toEqual({
+      message: null,
+      session_id: 'conv-only',
+    });
+  });
+
+  it('does not treat JSON-shaped Antigravity output as structured events', () => {
+    expect(parseAntigravityOutput('{"status":"ok"}', '')).toEqual({
+      message: '{"status":"ok"}',
+      session_id: null,
+    });
+  });
+});
+
+describe('peek on the Antigravity backend', () => {
+  const ts = '2026-04-11T14:44:53.820Z';
+
+  it('emits plain stdout text as peek messages', () => {
+    const extractor = new PeekMessageExtractor('gemini', { geminiBackend: 'antigravity' });
+
+    expect(extractor.push('Working on it\n', ts)).toEqual([{ ts, text: 'Working on it' }]);
+    expect(extractor.flush(ts)).toEqual([]);
+  });
+
+  it('emits JSON-shaped stdout lines as message text', () => {
+    const extractor = new PeekMessageExtractor('gemini', { geminiBackend: 'antigravity' });
+
+    expect(extractor.push('{"status":"ok"}\n', ts)).toEqual([{ ts, text: '{"status":"ok"}' }]);
+  });
+
+  it('flushes a trailing partial line', () => {
+    const extractor = new PeekMessageExtractor('gemini', { geminiBackend: 'antigravity' });
+
+    expect(extractor.push('no newline yet', ts)).toEqual([]);
+    expect(extractor.flush(ts)).toEqual([{ ts, text: 'no newline yet' }]);
+  });
+
+  it('suppresses the internal log lines written to stderr', () => {
+    const extractor = new PeekEventExtractor('gemini', {
+      source: 'stderr',
+      geminiBackend: 'antigravity',
+    });
+
+    expect(extractor.push('I0606 11:20:31.000000 main.go:1] Starting agy\n', ts)).toEqual([]);
+    expect(extractor.flush(ts)).toEqual([]);
+  });
+
+  it('keeps the Gemini CLI peek behaviour untouched by default', () => {
+    const extractor = new PeekMessageExtractor('gemini');
+
+    expect(extractor.push('{"type":"message","role":"assistant","content":"Visible","delta":true}\n', ts)).toEqual([]);
+    expect(extractor.flush(ts)).toEqual([{ ts, text: 'Visible' }]);
+  });
+});
+
+describe('models payload', () => {
+  it('exposes the legacy catalog and both backends by default', () => {
+    const payload = getModelsPayload();
+
+    expect(payload.gemini).toBe(GEMINI_MODELS);
+    expect(payload.geminiBackend).toBe('gemini-cli');
+    expect(payload.aliases).toEqual(expect.arrayContaining([
+      { name: 'gemini-ultra', resolvesTo: 'gemini-3.1-pro-preview', agent: 'gemini' },
+    ]));
+    expect(payload.geminiBackends['gemini-cli'].active).toBe(true);
+    expect(payload.geminiBackends['gemini-cli'].models).toBe(GEMINI_MODELS);
+    expect(payload.geminiBackends['gemini-cli'].cliBinaryDefault).toBe('gemini');
+    expect(payload.geminiBackends.antigravity.active).toBe(false);
+    expect(payload.geminiBackends.antigravity.models).toBe(ANTIGRAVITY_GEMINI_MODELS);
+    expect(payload.geminiBackends.antigravity.cliBinaryDefault).toBe('agy');
+  });
+
+  it('switches the gemini key to the Antigravity catalog when it is active', () => {
+    const payload = getModelsPayload('antigravity');
+
+    expect(payload.gemini).toBe(ANTIGRAVITY_GEMINI_MODELS);
+    expect(payload.geminiBackend).toBe('antigravity');
+    expect(payload.geminiBackends.antigravity.active).toBe(true);
+    expect(payload.geminiBackends['gemini-cli'].active).toBe(false);
+    expect(payload.aliases).toEqual(expect.arrayContaining([
+      { name: 'gemini-ultra', resolvesTo: 'Gemini 3.1 Pro (High)', agent: 'gemini' },
+    ]));
+    expect(payload.aliases.some((alias) => alias.resolvesTo === 'gemini-3.1-pro-preview')).toBe(false);
+  });
+});
+
+describe('CliProcessService on the Antigravity backend', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes --log-file through and reads the conversation id back from it', async () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-antigravity-'));
+    tempDirs.push(root);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'work');
+    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(workFolder, { recursive: true });
+
+    const scriptPath = join(root, 'agy');
+    writeFileSync(
+      scriptPath,
+      `#!/bin/bash
+log=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-file) log="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+if [[ -n "$log" ]]; then
+  echo 'I0606 11:20:32.000000 conv.go:9] Created conversation conv-e2e' > "$log"
+fi
+echo "Antigravity says hi"
+exit 0
+`
+    );
+    chmodSync(scriptPath, 0o755);
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: { ...ANTIGRAVITY_CLI_PATHS, gemini: scriptPath },
+    });
+
+    const started = await service.startProcess({
+      cwd: workFolder,
+      prompt: 'hi',
+      model: 'gemini-3.8-flash-high',
+    });
+    expect(started.agent).toBe('gemini');
+
+    const [result] = await service.waitForProcesses([started.pid], 30, true);
+    expect(result.status).toBe('completed');
+    expect(result.agentOutput).toEqual({
+      message: 'Antigravity says hi',
+      session_id: 'conv-e2e',
+    });
+  });
+});

--- a/src/__tests__/gemini-backend.test.ts
+++ b/src/__tests__/gemini-backend.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  DEFAULT_GEMINI_BACKEND_MODE,
+  getDefaultGeminiCliName,
+  isAntigravityCommand,
+  readGeminiBackendMode,
+  readGeminiBackendModeSafe,
+  resolveConfiguredGeminiBackend,
+  resolveGeminiBackend,
+  validateGeminiBackendEnv,
+} from '../model-catalog.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('readGeminiBackendMode', () => {
+  it('defaults to the gemini-cli backend when the variable is absent', () => {
+    expect(DEFAULT_GEMINI_BACKEND_MODE).toBe('gemini-cli');
+    expect(readGeminiBackendMode({})).toBe('gemini-cli');
+  });
+
+  it('defaults to the gemini-cli backend for an empty value', () => {
+    expect(readGeminiBackendMode({ GEMINI_CLI_BACKEND: '' })).toBe('gemini-cli');
+    expect(readGeminiBackendMode({ GEMINI_CLI_BACKEND: '   ' })).toBe('gemini-cli');
+  });
+
+  it('accepts every documented value, case-insensitively', () => {
+    expect(readGeminiBackendMode({ GEMINI_CLI_BACKEND: 'gemini-cli' })).toBe('gemini-cli');
+    expect(readGeminiBackendMode({ GEMINI_CLI_BACKEND: 'antigravity' })).toBe('antigravity');
+    expect(readGeminiBackendMode({ GEMINI_CLI_BACKEND: 'auto' })).toBe('auto');
+    expect(readGeminiBackendMode({ GEMINI_CLI_BACKEND: ' Antigravity ' })).toBe('antigravity');
+  });
+
+  it('throws a clear error for an unknown value', () => {
+    expect(() => readGeminiBackendMode({ GEMINI_CLI_BACKEND: 'agy' })).toThrow(
+      'Invalid GEMINI_CLI_BACKEND: agy. Allowed values: gemini-cli, antigravity, auto.'
+    );
+    expect(() => validateGeminiBackendEnv({ GEMINI_CLI_BACKEND: 'nope' })).toThrow(
+      /Invalid GEMINI_CLI_BACKEND/
+    );
+  });
+
+  it('falls back to the default in the non-throwing variant', () => {
+    expect(readGeminiBackendModeSafe({ GEMINI_CLI_BACKEND: 'nope' })).toBe('gemini-cli');
+  });
+});
+
+describe('isAntigravityCommand', () => {
+  it('matches the agy binary and its variants', () => {
+    expect(isAntigravityCommand('agy')).toBe(true);
+    expect(isAntigravityCommand('/usr/local/bin/agy')).toBe(true);
+    expect(isAntigravityCommand('agy-nightly')).toBe(true);
+    expect(isAntigravityCommand('C:\\tools\\agy.exe')).toBe(true);
+    expect(isAntigravityCommand('AGY')).toBe(true);
+  });
+
+  it('does not match the gemini binary or unrelated names', () => {
+    expect(isAntigravityCommand('gemini')).toBe(false);
+    expect(isAntigravityCommand('/usr/bin/gemini')).toBe(false);
+    expect(isAntigravityCommand('agyx')).toBe(false);
+    expect(isAntigravityCommand('')).toBe(false);
+  });
+});
+
+describe('resolveGeminiBackend', () => {
+  it('returns gemini-cli by default regardless of the resolved binary', () => {
+    expect(resolveGeminiBackend({ cliPath: '/usr/local/bin/agy', env: {} })).toBe('gemini-cli');
+  });
+
+  it('honours an explicit backend selection', () => {
+    expect(resolveGeminiBackend({ cliPath: '/usr/bin/gemini', env: { GEMINI_CLI_BACKEND: 'antigravity' } })).toBe('antigravity');
+    expect(resolveGeminiBackend({ cliPath: '/usr/local/bin/agy', env: { GEMINI_CLI_BACKEND: 'gemini-cli' } })).toBe('gemini-cli');
+  });
+
+  it('infers the backend from the resolved binary in auto mode', () => {
+    const env = { GEMINI_CLI_BACKEND: 'auto' };
+    expect(resolveGeminiBackend({ cliPath: '/usr/local/bin/agy', env })).toBe('antigravity');
+    expect(resolveGeminiBackend({ cliPath: 'agy-nightly', env })).toBe('antigravity');
+    expect(resolveGeminiBackend({ cliPath: '/usr/bin/gemini', env })).toBe('gemini-cli');
+    expect(resolveGeminiBackend({ env })).toBe('gemini-cli');
+  });
+
+  it('propagates the validation error for an unknown value', () => {
+    expect(() => resolveGeminiBackend({ cliPath: 'agy', env: { GEMINI_CLI_BACKEND: 'antigravty' } })).toThrow(
+      /Invalid GEMINI_CLI_BACKEND/
+    );
+  });
+});
+
+describe('getDefaultGeminiCliName', () => {
+  it('keeps gemini as the default binary unless Antigravity is selected', () => {
+    expect(getDefaultGeminiCliName({})).toBe('gemini');
+    expect(getDefaultGeminiCliName({ GEMINI_CLI_BACKEND: 'auto' })).toBe('gemini');
+    expect(getDefaultGeminiCliName({ GEMINI_CLI_BACKEND: 'antigravity' })).toBe('agy');
+  });
+});
+
+describe('resolveConfiguredGeminiBackend', () => {
+  it('reads the process environment when no explicit env is given', () => {
+    vi.stubEnv('GEMINI_CLI_BACKEND', '');
+    expect(resolveConfiguredGeminiBackend()).toBe('gemini-cli');
+    vi.stubEnv('GEMINI_CLI_BACKEND', 'antigravity');
+    expect(resolveConfiguredGeminiBackend()).toBe('antigravity');
+  });
+
+  it('resolves auto mode through GEMINI_CLI_NAME', () => {
+    expect(resolveConfiguredGeminiBackend({ GEMINI_CLI_BACKEND: 'auto' })).toBe('gemini-cli');
+    expect(resolveConfiguredGeminiBackend({ GEMINI_CLI_BACKEND: 'auto', GEMINI_CLI_NAME: 'agy' })).toBe('antigravity');
+  });
+});

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -1,7 +1,7 @@
 import { runMcpServer } from './mcp.js';
 import { CliProcessService } from '../cli-process-service.js';
 import { getCliDoctorStatus } from '../cli-utils.js';
-import { getModelsPayload } from '../model-catalog.js';
+import { getModelsPayload, resolveConfiguredGeminiBackend } from '../model-catalog.js';
 import { validatePeekPids, validatePeekTimeSec } from '../peek.js';
 
 export const CLI_HELP_TEXT = `Usage: ai-cli <command> [options]
@@ -30,7 +30,8 @@ Options:
   --prompt-file <path>         Path to a prompt file
   --model <model>              Model name or alias (e.g. sonnet, fable, claude-ultra, gpt-6-astra, codex-ultra, gemini-2.5-pro, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
   --session-id <id>            Resume a previous session, including OpenCode in-place resumes
-  --reasoning-effort <level>   Reasoning level for Claude/Codex only; unsupported for Gemini, Forge, and OpenCode
+  --reasoning-effort <level>   Reasoning level for Claude/Codex only; unsupported for Forge, OpenCode, and Gemini
+                               (Gemini accepts low|medium|high with GEMINI_CLI_BACKEND=antigravity)
   --help, -h                   Show this help message
 
 Compatibility aliases:
@@ -405,7 +406,7 @@ export async function runCli(argv: string[], deps: Partial<CliDeps> = {}): Promi
       stdout(MODELS_HELP_TEXT);
       return 0;
     }
-    writeJson(stdout, getModelsPayload());
+    writeJson(stdout, getModelsPayload(resolveConfiguredGeminiBackend()));
     return 0;
   }
 

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -10,7 +10,15 @@ import {
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { debugLog, getCliDoctorStatus, type CliBinaryStatus } from '../cli-utils.js';
-import { getModelParameterDescription, getModelsPayload, getSupportedModelsDescription } from '../model-catalog.js';
+import {
+  getModelParameterDescription,
+  getModelsPayload,
+  getReasoningEffortParameterDescription,
+  getSupportedModelsDescription,
+  resolveGeminiBackend,
+  validateGeminiBackendEnv,
+  type GeminiBackend,
+} from '../model-catalog.js';
 import { validatePeekPids, validatePeekTimeSec } from '../peek.js';
 import { ProcessService } from '../process-service.js';
 
@@ -74,12 +82,16 @@ export class ClaudeCodeServer {
   private claudeCliPath: string;
   private codexCliPath: string;
   private geminiCliPath: string;
+  private geminiBackend: GeminiBackend;
   private forgeCliPath: string;
   private opencodeCliPath: string;
   private processService: ProcessService;
   private sigintHandler?: () => Promise<void>;
 
   constructor() {
+    // Fail fast on an unknown GEMINI_CLI_BACKEND instead of silently running
+    // the gemini agent on the wrong CLI.
+    validateGeminiBackendEnv();
     const doctorStatus = getCliDoctorStatus();
     this.claudeCliPath = this.resolveDoctorCliPath(doctorStatus.claude);
     this.codexCliPath = this.resolveDoctorCliPath(doctorStatus.codex);
@@ -91,6 +103,10 @@ export class ClaudeCodeServer {
     console.error(`[Setup] Using Gemini CLI command/path: ${this.geminiCliPath}`);
     console.error(`[Setup] Using Forge CLI command/path: ${this.forgeCliPath}`);
     console.error(`[Setup] Using OpenCode CLI command/path: ${this.opencodeCliPath}`);
+    this.geminiBackend = resolveGeminiBackend({ cliPath: this.geminiCliPath });
+    if (this.geminiBackend !== 'gemini-cli') {
+      console.error(`[Setup] Serving the gemini agent with the ${this.geminiBackend} backend`);
+    }
     this.processService = new ProcessService({
       cliPaths: {
         claude: this.claudeCliPath,
@@ -154,7 +170,7 @@ export class ClaudeCodeServer {
 **IMPORTANT**: This tool now returns immediately with a PID. Use other tools to check status and get results.
 
 **Supported models**:
-${getSupportedModelsDescription()}
+${getSupportedModelsDescription(this.geminiBackend)}
 
 **Prompt input**: You must provide EITHER prompt (string) OR prompt_file (file path), but not both.
 
@@ -182,11 +198,11 @@ ${getSupportedModelsDescription()}
               },
               model: {
                 type: 'string',
-                description: getModelParameterDescription(),
+                description: getModelParameterDescription(this.geminiBackend),
               },
               reasoning_effort: {
                 type: 'string',
-                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high", "xhigh", "max". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh"; GPT-6 Astra and GPT-5.6 Sol/Terra also support "max" and "ultra", while GPT-5.6 Luna supports "max". Gemini, Forge, and OpenCode do not support reasoning_effort in this integration.',
+                description: getReasoningEffortParameterDescription(this.geminiBackend),
               },
               session_id: {
                 type: 'string',
@@ -498,7 +514,7 @@ ${getSupportedModelsDescription()}
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify(getModelsPayload(), null, 2)
+        text: JSON.stringify(getModelsPayload(this.geminiBackend), null, 2)
       }]
     };
   }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -1,14 +1,27 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve as pathResolve, isAbsolute } from 'node:path';
 import type { CliPaths } from './cli-utils.js';
-import { MODEL_ALIASES } from './model-catalog.js';
+import {
+  ANTIGRAVITY_REASONING_EFFORTS,
+  getAntigravityEffortsForModel,
+  getAntigravityModelBaseName,
+  getModelAliases,
+  getRequiredGeminiBackendForModel,
+  isAntigravityOnlyModel,
+  resolveAntigravityModelForEffort,
+  resolveGeminiBackend,
+  type GeminiBackend,
+} from './model-catalog.js';
 
 export const ALLOWED_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
 const CLAUDE_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
 const CODEX_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
 const CODEX_MAX_REASONING_MODELS = new Set(['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
 const CODEX_ULTRA_REASONING_MODELS = new Set(['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra']);
+const ANTIGRAVITY_ALLOWED_REASONING_EFFORTS = new Set<string>(ANTIGRAVITY_REASONING_EFFORTS);
 const OPENCODE_MODEL_ERROR = 'Invalid OpenCode model. Expected exact syntax oc-<provider/model>.';
+/** Antigravity runs headless one-shot prompts; two hours covers long agent runs. */
+export const DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT = '2h';
 
 type Agent = 'codex' | 'claude' | 'gemini' | 'forge' | 'opencode';
 
@@ -29,6 +42,11 @@ function getStandardAgentForModel(model: string): Exclude<Agent, 'opencode'> {
     return 'codex';
   }
   if (model.startsWith('gemini')) {
+    return 'gemini';
+  }
+  // Antigravity display names such as "Gemini 3.8 Flash (High)" are also the
+  // gemini agent; every other string keeps routing to Claude as before.
+  if (isAntigravityOnlyModel(model)) {
     return 'gemini';
   }
   return 'claude';
@@ -62,7 +80,7 @@ function extractOpenCodeModel(rawModel: string): string {
   return remainder;
 }
 
-function resolveModelSelection(rawModel: string): ModelSelection {
+function resolveModelSelection(rawModel: string, geminiBackend: GeminiBackend): ModelSelection {
   if (rawModel === 'opencode') {
     return {
       agent: 'opencode',
@@ -79,7 +97,7 @@ function resolveModelSelection(rawModel: string): ModelSelection {
     };
   }
 
-  const resolvedModel = resolveModelAlias(rawModel);
+  const resolvedModel = resolveModelAlias(rawModel, geminiBackend);
   return {
     agent: getStandardAgentForModel(resolvedModel),
     resolvedModel,
@@ -87,11 +105,32 @@ function resolveModelSelection(rawModel: string): ModelSelection {
   };
 }
 
-export function resolveModelAlias(model: string): string {
-  return MODEL_ALIASES[model] || model;
+export function resolveModelAlias(model: string, geminiBackend: GeminiBackend = 'gemini-cli'): string {
+  return getModelAliases(geminiBackend)[model] || model;
 }
 
-export function getReasoningEffort(model: string, rawValue: unknown): string {
+/**
+ * Rejects a Gemini model that belongs to the other backend, naming the
+ * GEMINI_CLI_BACKEND value it requires. Identifiers unknown to both catalogs
+ * are passed through to the selected CLI untouched.
+ */
+function assertGeminiModelMatchesBackend(rawModel: string, resolvedModel: string, geminiBackend: GeminiBackend): void {
+  const requiredBackend = getRequiredGeminiBackendForModel(rawModel)
+    ?? getRequiredGeminiBackendForModel(resolvedModel);
+  if (!requiredBackend || requiredBackend === geminiBackend) {
+    return;
+  }
+
+  throw new Error(
+    `Model "${rawModel}" belongs to the ${requiredBackend} Gemini backend and requires GEMINI_CLI_BACKEND=${requiredBackend}. The active Gemini backend is ${geminiBackend}.`
+  );
+}
+
+export function getReasoningEffort(
+  model: string,
+  rawValue: unknown,
+  geminiBackend: GeminiBackend = 'gemini-cli',
+): string {
   if (typeof rawValue !== 'string') {
     return '';
   }
@@ -115,9 +154,17 @@ export function getReasoningEffort(model: string, rawValue: unknown): string {
     throw new Error('reasoning_effort is not supported for forge.');
   }
   if (agent === 'gemini') {
-    throw new Error(
-      'reasoning_effort is only supported for Claude and Codex models.'
-    );
+    if (geminiBackend !== 'antigravity') {
+      throw new Error(
+        'reasoning_effort is only supported for Claude and Codex models.'
+      );
+    }
+    if (!ANTIGRAVITY_ALLOWED_REASONING_EFFORTS.has(normalized)) {
+      throw new Error(
+        'Gemini reasoning_effort supports only low, medium, high.'
+      );
+    }
+    return normalized;
   }
   if (agent === 'claude' && !CLAUDE_REASONING_EFFORTS.has(normalized)) {
     throw new Error(
@@ -149,6 +196,8 @@ export interface CliCommand {
   agent: Agent;
   prompt: string;
   resolvedModel: string;
+  /** Backend serving the gemini agent, or null for every other agent. */
+  geminiBackend: GeminiBackend | null;
 }
 
 export interface BuildCliCommandOptions {
@@ -158,6 +207,10 @@ export interface BuildCliCommandOptions {
   model?: string;
   session_id?: string;
   reasoning_effort?: string;
+  /** Antigravity only: file the CLI writes its internal log to. */
+  log_file?: string;
+  /** Antigravity only: value of --print-timeout. */
+  antigravityPrintTimeout?: string;
   cliPaths: CliPaths;
 }
 
@@ -202,7 +255,11 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
   }
 
   const rawModel = options.model || '';
-  const { agent, resolvedModel, openCodeModel } = resolveModelSelection(rawModel);
+  const geminiBackend = resolveGeminiBackend({ cliPath: options.cliPaths.gemini });
+  const { agent, resolvedModel, openCodeModel } = resolveModelSelection(rawModel, geminiBackend);
+  if (agent === 'gemini') {
+    assertGeminiModelMatchesBackend(rawModel, resolvedModel, geminiBackend);
+  }
 
   let reasoningEffortArg: string | undefined = options.reasoning_effort;
   if (!reasoningEffortArg) {
@@ -216,7 +273,24 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
   const reasoningTargetModel = rawModel === 'opencode' || rawModel.startsWith('oc-')
     ? rawModel
     : (resolvedModel || rawModel);
-  const reasoningEffort = getReasoningEffort(reasoningTargetModel, reasoningEffortArg);
+  const reasoningEffort = getReasoningEffort(reasoningTargetModel, reasoningEffortArg, geminiBackend);
+
+  // Antigravity picks the reasoning level through the model NAME, so a
+  // reasoning_effort for the gemini agent becomes the (Low|Medium|High) variant.
+  let effectiveModel = resolvedModel;
+  if (agent === 'gemini' && geminiBackend === 'antigravity' && reasoningEffort) {
+    const variant = resolveAntigravityModelForEffort(resolvedModel, reasoningEffort);
+    if (!variant) {
+      const supported = getAntigravityEffortsForModel(resolvedModel);
+      const baseName = getAntigravityModelBaseName(resolvedModel) || resolvedModel;
+      throw new Error(
+        supported.length > 0
+          ? `Gemini reasoning_effort for ${baseName} supports only ${supported.join(', ')}.`
+          : `reasoning_effort is not supported for Gemini model ${resolvedModel}.`
+      );
+    }
+    effectiveModel = variant;
+  }
 
   let cliPath: string;
   let args: string[];
@@ -238,6 +312,30 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     }
 
     args.push('--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', '--json', prompt);
+  } else if (agent === 'gemini' && geminiBackend === 'antigravity') {
+    // Antigravity CLI (agy), headless one-shot mode: -p prints the answer,
+    // --dangerously-skip-permissions auto-approves tools, --model takes the
+    // display name (or its slug), and sessions resume through --conversation.
+    // agy supports neither -y nor --output-format; stdout is plain text.
+    cliPath = options.cliPaths.gemini;
+    const printTimeout = options.antigravityPrintTimeout?.trim()
+      || process.env.GEMINI_PRINT_TIMEOUT?.trim()
+      || DEFAULT_ANTIGRAVITY_PRINT_TIMEOUT;
+    args = ['--dangerously-skip-permissions', '--print-timeout', printTimeout];
+
+    if (options.log_file && typeof options.log_file === 'string' && options.log_file.trim()) {
+      args.push('--log-file', options.log_file);
+    }
+
+    if (options.session_id && typeof options.session_id === 'string') {
+      args.push('--conversation', options.session_id);
+    }
+
+    if (effectiveModel) {
+      args.push('--model', effectiveModel);
+    }
+
+    args.push('-p', prompt);
   } else if (agent === 'gemini') {
     cliPath = options.cliPaths.gemini;
     args = ['-y', '--output-format', 'stream-json'];
@@ -291,5 +389,13 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     }
   }
 
-  return { cliPath, args, cwd, agent, prompt, resolvedModel };
+  return {
+    cliPath,
+    args,
+    cwd,
+    agent,
+    prompt,
+    resolvedModel: effectiveModel,
+    geminiBackend: agent === 'gemini' ? geminiBackend : null,
+  };
 }

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -1,4 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import {
   appendFileSync,
   closeSync,
@@ -19,7 +20,8 @@ import { join, basename, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
+import type { GeminiBackend } from './model-catalog.js';
+import { parseAntigravityOutput, parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import { buildProcessResult } from './process-result.js';
 import {
   appendPeekEvents,
@@ -42,6 +44,9 @@ interface StoredProcess {
   startTime: string;
   stdoutPath: string;
   stderrPath: string;
+  /** Antigravity only: path of the CLI log file holding the conversation id. */
+  logPath?: string;
+  geminiBackend?: GeminiBackend | null;
   status: 'running' | 'completed' | 'failed';
   exitCode?: number;
 }
@@ -90,9 +95,18 @@ function normalizeCwdForStorage(cwd: string): string {
     .join('');
 }
 
-function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any {
+function parseAgentOutput(
+  agent: AgentType,
+  stdout: string,
+  stderr: string,
+  options: { geminiBackend?: GeminiBackend | null; logText?: string } = {},
+): any {
   if (agent === 'codex') {
     return parseCodexOutput(`${stdout}\n${stderr}`);
+  }
+
+  if (agent === 'gemini' && options.geminiBackend === 'antigravity') {
+    return parseAntigravityOutput(stdout, options.logText || '');
   }
 
   if (!stdout) {
@@ -131,7 +145,7 @@ export class CliProcessService {
   }
 
   async startProcess(options: CliRunOptions): Promise<{ pid: number; status: 'started'; agent: AgentType; message: string }> {
-    const cmd = buildCliCommand({
+    let cmd = buildCliCommand({
       prompt: options.prompt,
       prompt_file: options.prompt_file,
       workFolder: options.cwd,
@@ -141,7 +155,24 @@ export class CliProcessService {
       cliPaths: this.cliPaths,
     });
 
-    return this.startDetachedTrackedProcess(cmd, options.model);
+    // Antigravity prints no conversation id on stdout, so it is asked to write
+    // its internal log to a file the adapter can read the id back from.
+    let logPath: string | undefined;
+    if (cmd.geminiBackend === 'antigravity') {
+      logPath = this.createAntigravityLogPath();
+      cmd = buildCliCommand({
+        prompt: options.prompt,
+        prompt_file: options.prompt_file,
+        workFolder: options.cwd,
+        model: options.model,
+        session_id: options.session_id,
+        reasoning_effort: options.reasoning_effort,
+        log_file: logPath,
+        cliPaths: this.cliPaths,
+      });
+    }
+
+    return this.startDetachedTrackedProcess(cmd, options.model, logPath);
   }
 
   async listProcesses(): Promise<ProcessListItem[]> {
@@ -157,7 +188,10 @@ export class CliProcessService {
     const refreshed = this.refreshStatus(storedProcess);
     const stdout = this.readTextFileSafe(refreshed.stdoutPath);
     const stderr = this.readTextFileSafe(refreshed.stderrPath);
-    const agentOutput = parseAgentOutput(refreshed.toolType, stdout, stderr);
+    const agentOutput = parseAgentOutput(refreshed.toolType, stdout, stderr, {
+      geminiBackend: refreshed.geminiBackend,
+      logText: refreshed.logPath ? this.readTextFileSafe(refreshed.logPath) : '',
+    });
 
     return buildProcessResult({
       pid,
@@ -227,8 +261,16 @@ export class CliProcessService {
       observers.push({
         process,
         result,
-        stdoutExtractor: new PeekEventExtractor(process.toolType, { includeToolCalls, source: 'stdout' }),
-        stderrExtractor: new PeekEventExtractor(process.toolType, { includeToolCalls, source: 'stderr' }),
+        stdoutExtractor: new PeekEventExtractor(process.toolType, {
+          includeToolCalls,
+          source: 'stdout',
+          geminiBackend: process.geminiBackend ?? undefined,
+        }),
+        stderrExtractor: new PeekEventExtractor(process.toolType, {
+          includeToolCalls,
+          source: 'stderr',
+          geminiBackend: process.geminiBackend ?? undefined,
+        }),
         stdoutOffset: this.fileSizeSafe(process.stdoutPath),
         stderrOffset: this.fileSizeSafe(process.stderrPath),
       });
@@ -335,6 +377,10 @@ export class CliProcessService {
         continue;
       }
 
+      if (refreshed.logPath && existsSync(refreshed.logPath)) {
+        rmSync(refreshed.logPath, { force: true });
+      }
+
       const processDir = this.resolveStoredProcessDir(refreshed);
       if (existsSync(processDir)) {
         rmSync(processDir, { recursive: true, force: true });
@@ -353,6 +399,7 @@ export class CliProcessService {
   private async startDetachedTrackedProcess(
     cmd: Awaited<ReturnType<typeof buildCliCommand>>,
     model: string | undefined,
+    logPath?: string,
   ): Promise<{ pid: number; status: 'started'; agent: AgentType; message: string }> {
     const cwdKey = this.resolveCwdKey(cmd.cwd);
     const runnerPath = this.resolveDetachedRunnerPath();
@@ -389,6 +436,8 @@ export class CliProcessService {
       startTime: new Date().toISOString(),
       stdoutPath,
       stderrPath,
+      logPath,
+      geminiBackend: cmd.geminiBackend,
       status: 'running',
     };
     this.writeProcess(storedProcess);
@@ -490,6 +539,12 @@ export class CliProcessService {
     const tempPath = `${exitStatusPath}.${process.pid}.${Date.now()}.tmp`;
     writeFileSync(tempPath, JSON.stringify(exitStatus, null, 2) + '\n');
     renameSync(tempPath, exitStatusPath);
+  }
+
+  private createAntigravityLogPath(): string {
+    const logDir = join(this.stateDir, 'logs');
+    mkdirSync(logDir, { recursive: true });
+    return join(logDir, `${randomUUID()}.antigravity.log`);
   }
 
   private readTextFileSafe(filePath: string): string {

--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -2,6 +2,11 @@ import { accessSync, constants } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as path from 'path';
+import {
+  DEFAULT_ANTIGRAVITY_CLI_NAME,
+  DEFAULT_GEMINI_CLI_NAME,
+  readGeminiBackendModeSafe,
+} from './model-catalog.js';
 
 const debugMode = process.env.MCP_CLAUDE_DEBUG === 'true';
 
@@ -221,11 +226,15 @@ function getCliBinaryConfig(name: CliBinaryName): {
     };
   }
 
+  // The gemini agent defaults to the Gemini CLI. Only GEMINI_CLI_BACKEND=antigravity
+  // switches the default binary to the official Antigravity CLI (agy), so doctor
+  // never reports agy as missing for anyone who has not opted in.
+  const usesAntigravity = readGeminiBackendModeSafe() === 'antigravity';
   return {
     envVarName: 'GEMINI_CLI_NAME',
     customCliName: process.env.GEMINI_CLI_NAME,
-    defaultCliName: 'gemini',
-    localInstallPath: join(homedir(), '.gemini', 'local', 'gemini'),
+    defaultCliName: usesAntigravity ? DEFAULT_ANTIGRAVITY_CLI_NAME : DEFAULT_GEMINI_CLI_NAME,
+    localInstallPath: usesAntigravity ? undefined : join(homedir(), '.gemini', 'local', 'gemini'),
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,7 +40,8 @@ Options:
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt
   --session_id         Session ID to resume, including OpenCode in-place resumes
-  --reasoning_effort   Claude/Codex only: Claude=low|medium|high|xhigh|max, Codex=low|medium|high|xhigh (GPT-6 Astra/GPT-5.6: max; Astra/Sol/Terra: ultra); unsupported for Gemini, Forge, and OpenCode
+  --reasoning_effort   Claude=low|medium|high|xhigh|max, Codex=low|medium|high|xhigh (GPT-6 Astra/GPT-5.6: max; Astra/Sol/Terra: ultra); unsupported for Gemini, Forge, and OpenCode
+                       (Gemini accepts low|medium|high with GEMINI_CLI_BACKEND=antigravity, selecting the matching agy model variant)
   --help               Show this help message
 
 Raw CLI output goes to stdout. Use cli.run.parse to parse the output:

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,3 +1,120 @@
+/**
+ * Backend selection for the "gemini" agent.
+ *
+ * The agent can be served either by the historical Gemini CLI (`gemini`) or by
+ * the Antigravity CLI (`agy`). The two CLIs share nothing: different flags,
+ * different model identifiers and a different output format, so the backend is
+ * selected explicitly through the GEMINI_CLI_BACKEND environment variable.
+ *
+ * The default is `gemini-cli`, which keeps the historical behavior byte for
+ * byte for anyone who does not opt in.
+ */
+
+export const GEMINI_BACKEND_ENV_VAR = 'GEMINI_CLI_BACKEND';
+
+/** Backends the agent can actually run on, once `auto` has been resolved. */
+export const GEMINI_BACKENDS = ['gemini-cli', 'antigravity'] as const;
+export type GeminiBackend = (typeof GEMINI_BACKENDS)[number];
+
+/** Accepted values of GEMINI_CLI_BACKEND. */
+export const GEMINI_BACKEND_MODES = ['gemini-cli', 'antigravity', 'auto'] as const;
+export type GeminiBackendMode = (typeof GEMINI_BACKEND_MODES)[number];
+
+export const DEFAULT_GEMINI_BACKEND_MODE: GeminiBackendMode = 'gemini-cli';
+
+/** Default binary name per backend. Both are overridable with GEMINI_CLI_NAME. */
+export const DEFAULT_GEMINI_CLI_NAME = 'gemini';
+export const DEFAULT_ANTIGRAVITY_CLI_NAME = 'agy';
+
+const WINDOWS_EXECUTABLE_EXTENSION_PATTERN = /\.(exe|cmd|bat|com|ps1)$/;
+
+function invalidBackendError(rawValue: string): Error {
+  return new Error(
+    `Invalid ${GEMINI_BACKEND_ENV_VAR}: ${rawValue}. Allowed values: ${GEMINI_BACKEND_MODES.join(', ')}.`
+  );
+}
+
+/**
+ * Reads GEMINI_CLI_BACKEND. Throws on an unknown value so a typo fails loudly
+ * instead of silently falling back to the wrong CLI.
+ */
+export function readGeminiBackendMode(env: NodeJS.ProcessEnv = process.env): GeminiBackendMode {
+  const rawValue = env[GEMINI_BACKEND_ENV_VAR];
+  if (typeof rawValue !== 'string' || !rawValue.trim()) {
+    return DEFAULT_GEMINI_BACKEND_MODE;
+  }
+
+  const normalized = rawValue.trim().toLowerCase();
+  if ((GEMINI_BACKEND_MODES as readonly string[]).includes(normalized)) {
+    return normalized as GeminiBackendMode;
+  }
+
+  throw invalidBackendError(rawValue);
+}
+
+/**
+ * Same as readGeminiBackendMode, but falls back to the default instead of
+ * throwing. Used by diagnostics that must keep reporting on a bad value.
+ */
+export function readGeminiBackendModeSafe(env: NodeJS.ProcessEnv = process.env): GeminiBackendMode {
+  try {
+    return readGeminiBackendMode(env);
+  } catch {
+    return DEFAULT_GEMINI_BACKEND_MODE;
+  }
+}
+
+/** Throws when GEMINI_CLI_BACKEND holds an unknown value. */
+export function validateGeminiBackendEnv(env: NodeJS.ProcessEnv = process.env): void {
+  readGeminiBackendMode(env);
+}
+
+/** True when the command basename is the Antigravity CLI (`agy`, `agy-*`). */
+export function isAntigravityCommand(command: string): boolean {
+  if (typeof command !== 'string' || !command.trim()) {
+    return false;
+  }
+
+  const normalized = command.trim().replace(/\\/g, '/');
+  const basename = normalized.slice(normalized.lastIndexOf('/') + 1).toLowerCase();
+  const withoutExtension = basename.replace(WINDOWS_EXECUTABLE_EXTENSION_PATTERN, '');
+  return withoutExtension === DEFAULT_ANTIGRAVITY_CLI_NAME
+    || withoutExtension.startsWith(`${DEFAULT_ANTIGRAVITY_CLI_NAME}-`);
+}
+
+/**
+ * Resolves the effective backend. In `auto` mode the decision comes from the
+ * resolved gemini command: an `agy`-like basename selects Antigravity.
+ */
+export function resolveGeminiBackend(
+  options: { cliPath?: string | null; env?: NodeJS.ProcessEnv } = {},
+): GeminiBackend {
+  const mode = readGeminiBackendMode(options.env ?? process.env);
+  if (mode !== 'auto') {
+    return mode;
+  }
+
+  return isAntigravityCommand(options.cliPath ?? '') ? 'antigravity' : 'gemini-cli';
+}
+
+/** Default binary name for the currently selected backend. */
+export function getDefaultGeminiCliName(env: NodeJS.ProcessEnv = process.env): string {
+  return readGeminiBackendModeSafe(env) === 'antigravity'
+    ? DEFAULT_ANTIGRAVITY_CLI_NAME
+    : DEFAULT_GEMINI_CLI_NAME;
+}
+
+/**
+ * Backend implied by the environment alone, without a resolved CLI path. Used
+ * where only the configuration is available (`ai-cli models`, docs strings).
+ */
+export function resolveConfiguredGeminiBackend(env: NodeJS.ProcessEnv = process.env): GeminiBackend {
+  return resolveGeminiBackend({
+    cliPath: env.GEMINI_CLI_NAME || getDefaultGeminiCliName(env),
+    env,
+  });
+}
+
 export const CLAUDE_MODELS = ['sonnet', 'sonnet[1m]', 'opus', 'opusplan', 'fable', 'haiku'] as const;
 export const CODEX_MODELS = [
   'gpt-6-astra',
@@ -11,12 +128,34 @@ export const CODEX_MODELS = [
   'gpt-5.3-codex-spark',
   'gpt-5.2',
 ] as const;
+/** Models of the "gemini" agent when it is served by the Gemini CLI (default). */
 export const GEMINI_MODELS = [
   'gemini-2.5-pro',
   'gemini-2.5-flash',
   'gemini-3.1-pro-preview',
   'gemini-3-pro-preview',
   'gemini-3-flash-preview',
+] as const;
+/**
+ * Models of the "gemini" agent when it is served by the Antigravity CLI (agy),
+ * i.e. when GEMINI_CLI_BACKEND=antigravity.
+ *
+ * These display names are the identifiers `agy --model` accepts, and they
+ * encode the reasoning level in the name itself. The lowercase slugs below
+ * (e.g. "gemini-3.8-flash-high") are accepted as aliases for convenience.
+ */
+export const ANTIGRAVITY_GEMINI_MODELS = [
+  'Gemini 3.8 Flash (High)',
+  'Gemini 3.8 Flash (Medium)',
+  'Gemini 3.8 Flash (Low)',
+  'Gemini 3.7 Flash (High)',
+  'Gemini 3.7 Flash (Medium)',
+  'Gemini 3.7 Flash (Low)',
+  'Gemini 3.6 Flash (High)',
+  'Gemini 3.6 Flash (Medium)',
+  'Gemini 3.6 Flash (Low)',
+  'Gemini 3.1 Pro (High)',
+  'Gemini 3.1 Pro (Low)',
 ] as const;
 export const FORGE_MODELS = ['forge'] as const;
 export const OPENCODE_MODELS = ['opencode'] as const;
@@ -27,11 +166,151 @@ export const MODEL_ALIASES: Record<string, string> = {
   'gemini-ultra': 'gemini-3.1-pro-preview',
 };
 
+/**
+ * Aliases that only exist under GEMINI_CLI_BACKEND=antigravity. They are purely
+ * additive: none of these keys collides with a Gemini CLI model name, and
+ * "gemini-ultra" is the single shared alias, resolved per backend.
+ */
+export const ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
+  'gemini-ultra': 'Gemini 3.1 Pro (High)',
+  'gemini-3.8-flash-high': 'Gemini 3.8 Flash (High)',
+  'gemini-3.8-flash-medium': 'Gemini 3.8 Flash (Medium)',
+  'gemini-3.8-flash': 'Gemini 3.8 Flash (Medium)',
+  'gemini-3.8-flash-low': 'Gemini 3.8 Flash (Low)',
+  'gemini-3.7-flash-high': 'Gemini 3.7 Flash (High)',
+  'gemini-3.7-flash-medium': 'Gemini 3.7 Flash (Medium)',
+  'gemini-3.7-flash': 'Gemini 3.7 Flash (Medium)',
+  'gemini-3.7-flash-low': 'Gemini 3.7 Flash (Low)',
+  'gemini-3.6-flash-high': 'Gemini 3.6 Flash (High)',
+  'gemini-3.6-flash-medium': 'Gemini 3.6 Flash (Medium)',
+  'gemini-3.6-flash': 'Gemini 3.6 Flash (Medium)',
+  'gemini-3.6-flash-low': 'Gemini 3.6 Flash (Low)',
+  'gemini-3.1-pro-high': 'Gemini 3.1 Pro (High)',
+  'gemini-3.1-pro': 'Gemini 3.1 Pro (High)',
+  'gemini-3.1-pro-low': 'Gemini 3.1 Pro (Low)',
+};
+
 export const MODEL_ALIAS_DETAILS = [
   { name: 'claude-ultra', resolvesTo: 'opus', agent: 'claude', defaultReasoningEffort: 'max' },
   { name: 'codex-ultra', resolvesTo: 'gpt-6-astra', agent: 'codex', defaultReasoningEffort: 'ultra' },
   { name: 'gemini-ultra', resolvesTo: 'gemini-3.1-pro-preview', agent: 'gemini' },
 ] as const;
+
+export const ANTIGRAVITY_MODEL_ALIAS_DETAILS = Object.entries(ANTIGRAVITY_MODEL_ALIASES)
+  .map(([name, resolvesTo]) => ({ name, resolvesTo, agent: 'gemini' as const }));
+
+export interface ModelAliasDetail {
+  name: string;
+  resolvesTo: string;
+  agent: string;
+  defaultReasoningEffort?: string;
+}
+
+/** Alias table in effect for the given Gemini backend. */
+export function getModelAliases(geminiBackend: GeminiBackend = 'gemini-cli'): Record<string, string> {
+  if (geminiBackend !== 'antigravity') {
+    return MODEL_ALIASES;
+  }
+
+  return { ...MODEL_ALIASES, ...ANTIGRAVITY_MODEL_ALIASES };
+}
+
+/** Documented alias list in effect for the given Gemini backend. */
+export function getModelAliasDetails(geminiBackend: GeminiBackend = 'gemini-cli'): ReadonlyArray<ModelAliasDetail> {
+  if (geminiBackend !== 'antigravity') {
+    return MODEL_ALIAS_DETAILS;
+  }
+
+  const nonGeminiAliases = MODEL_ALIAS_DETAILS.filter((alias) => alias.agent !== 'gemini');
+  return [...nonGeminiAliases, ...ANTIGRAVITY_MODEL_ALIAS_DETAILS];
+}
+
+/** Model list of the "gemini" agent for the given backend. */
+export function getGeminiModelsForBackend(geminiBackend: GeminiBackend = 'gemini-cli'): ReadonlyArray<string> {
+  return geminiBackend === 'antigravity' ? ANTIGRAVITY_GEMINI_MODELS : GEMINI_MODELS;
+}
+
+const GEMINI_CLI_ONLY_MODELS = new Set<string>(GEMINI_MODELS);
+
+const ANTIGRAVITY_ONLY_MODELS = new Set<string>([
+  ...ANTIGRAVITY_GEMINI_MODELS.map((model) => model.toLowerCase()),
+  ...Object.keys(ANTIGRAVITY_MODEL_ALIASES).filter((alias) => !(alias in MODEL_ALIASES)),
+]);
+
+/** True for an identifier only the Antigravity CLI understands. */
+export function isAntigravityOnlyModel(model: string): boolean {
+  return typeof model === 'string' && ANTIGRAVITY_ONLY_MODELS.has(model.trim().toLowerCase());
+}
+
+/** True for an identifier only the Gemini CLI understands. */
+export function isGeminiCliOnlyModel(model: string): boolean {
+  return typeof model === 'string' && GEMINI_CLI_ONLY_MODELS.has(model.trim());
+}
+
+/**
+ * Backend a model identifier requires, or null when the identifier is shared
+ * (e.g. "gemini-ultra") or unknown to both catalogs, in which case it is passed
+ * through to the selected CLI untouched.
+ */
+export function getRequiredGeminiBackendForModel(model: string): GeminiBackend | null {
+  if (isAntigravityOnlyModel(model)) {
+    return 'antigravity';
+  }
+  if (isGeminiCliOnlyModel(model)) {
+    return 'gemini-cli';
+  }
+  return null;
+}
+
+/**
+ * The Antigravity CLI encodes the reasoning level in the model name itself
+ * ("Gemini 3.8 Flash (High)"), so a reasoning_effort of low/medium/high is
+ * resolved into the matching catalog variant instead of a CLI flag.
+ */
+export const ANTIGRAVITY_REASONING_EFFORTS = ['low', 'medium', 'high'] as const;
+
+const ANTIGRAVITY_EFFORT_SUFFIX_PATTERN = /\s*\((Low|Medium|High)\)\s*$/i;
+
+/** Model name without its "(Low|Medium|High)" suffix. */
+export function getAntigravityModelBaseName(model: string): string {
+  return model.replace(ANTIGRAVITY_EFFORT_SUFFIX_PATTERN, '').trim();
+}
+
+/** Effort variants published for the family of the given model. */
+export function getAntigravityEffortsForModel(model: string): string[] {
+  const base = getAntigravityModelBaseName(model).toLowerCase();
+  const efforts: string[] = [];
+  for (const candidate of ANTIGRAVITY_GEMINI_MODELS) {
+    if (getAntigravityModelBaseName(candidate).toLowerCase() !== base) {
+      continue;
+    }
+    const suffix = ANTIGRAVITY_EFFORT_SUFFIX_PATTERN.exec(candidate);
+    if (suffix) {
+      efforts.push(suffix[1].toLowerCase());
+    }
+  }
+  return efforts;
+}
+
+/**
+ * Resolves the Antigravity model name for the requested effort, or null when
+ * the model family does not publish that variant.
+ */
+export function resolveAntigravityModelForEffort(model: string, effort: string): string | null {
+  const normalizedEffort = effort.trim().toLowerCase();
+  if (!(ANTIGRAVITY_REASONING_EFFORTS as readonly string[]).includes(normalizedEffort)) {
+    return null;
+  }
+
+  const base = getAntigravityModelBaseName(model);
+  if (!base) {
+    return null;
+  }
+
+  const label = `${normalizedEffort.charAt(0).toUpperCase()}${normalizedEffort.slice(1)}`;
+  const candidate = `${base} (${label})`.toLowerCase();
+  return ANTIGRAVITY_GEMINI_MODELS.find((known) => known.toLowerCase() === candidate) ?? null;
+}
 
 export interface DynamicModelBackendDescription {
   explicitPrefix: string;
@@ -40,40 +319,80 @@ export interface DynamicModelBackendDescription {
   modelsAreDynamic: boolean;
 }
 
-export function getSupportedModelsDescription(): string {
+export interface GeminiBackendDescription {
+  models: ReadonlyArray<string>;
+  aliases: ReadonlyArray<ModelAliasDetail>;
+  cliBinaryDefault: string;
+  active: boolean;
+}
+
+export function getSupportedModelsDescription(geminiBackend: GeminiBackend = 'gemini-cli'): string {
   return [
     '"claude-ultra", "codex-ultra", "gemini-ultra"',
     ...CLAUDE_MODELS.map((model) => `"${model}"`),
     ...CODEX_MODELS.map((model) => `"${model}"`),
-    ...GEMINI_MODELS.map((model) => `"${model}"`),
+    ...getGeminiModelsForBackend(geminiBackend).map((model) => `"${model}"`),
     ...FORGE_MODELS.map((model) => `"${model}"`),
     ...OPENCODE_MODELS.map((model) => `"${model}"`),
     '"oc-<provider/model>"',
   ].join(', ');
 }
 
-export function getModelParameterDescription(): string {
-  return `The model to use. Aliases: "claude-ultra" (Opus with auto max effort; does not select Fable), "codex-ultra" (auto ultra reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...GEMINI_MODELS, ...FORGE_MODELS, ...OPENCODE_MODELS].map((model) => `"${model}"`).join(', ')}. Fable is an explicit selection and may require usage credits. OpenCode also accepts explicit dynamic models using "oc-<provider/model>". "forge" is a provider key, not a Forge model family selector.`;
+export function getModelParameterDescription(geminiBackend: GeminiBackend = 'gemini-cli'): string {
+  const geminiModels = getGeminiModelsForBackend(geminiBackend);
+  // The default backend keeps the historical description untouched; the extra
+  // sentence only shows up once the Antigravity backend is selected.
+  const geminiNote = geminiBackend === 'antigravity'
+    ? ` Gemini models are served by the Antigravity CLI (agy) because ${GEMINI_BACKEND_ENV_VAR}=antigravity; the reasoning level is part of the model name, lowercase aliases such as "gemini-3.8-flash-high", "gemini-3.8-flash" (Medium) and "gemini-3.8-flash-low" resolve to them, and reasoning_effort "low", "medium" or "high" selects the matching variant.`
+    : '';
+  return `The model to use. Aliases: "claude-ultra" (Opus with auto max effort; does not select Fable), "codex-ultra" (auto ultra reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...geminiModels, ...FORGE_MODELS, ...OPENCODE_MODELS].map((model) => `"${model}"`).join(', ')}. Fable is an explicit selection and may require usage credits.${geminiNote} OpenCode also accepts explicit dynamic models using "oc-<provider/model>". "forge" is a provider key, not a Forge model family selector.`;
 }
 
-export function getModelsPayload(): {
-  aliases: ReadonlyArray<(typeof MODEL_ALIAS_DETAILS)[number]>;
+export function getReasoningEffortParameterDescription(geminiBackend: GeminiBackend = 'gemini-cli'): string {
+  const geminiNote = geminiBackend === 'antigravity'
+    ? 'Gemini on the Antigravity CLI (agy) accepts "low", "medium", "high" and selects the matching model variant, e.g. model "gemini-3.8-flash" with reasoning_effort "high" runs "Gemini 3.8 Flash (High)"; Gemini 3.1 Pro only has "low" and "high". Forge and OpenCode do not support reasoning_effort in this integration.'
+    : 'Gemini, Forge, and OpenCode do not support reasoning_effort in this integration.';
+  return `Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high", "xhigh", "max". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh"; GPT-6 Astra and GPT-5.6 Sol/Terra also support "max" and "ultra", while GPT-5.6 Luna supports "max". ${geminiNote}`;
+}
+
+export function getModelsPayload(geminiBackend: GeminiBackend = 'gemini-cli'): {
+  aliases: ReadonlyArray<ModelAliasDetail>;
   claude: ReadonlyArray<string>;
   codex: ReadonlyArray<string>;
   gemini: ReadonlyArray<string>;
   forge: ReadonlyArray<string>;
   opencode: ReadonlyArray<string>;
+  geminiBackend: GeminiBackend;
+  geminiBackends: {
+    'gemini-cli': GeminiBackendDescription;
+    antigravity: GeminiBackendDescription;
+  };
   dynamicModelBackends: {
     opencode: DynamicModelBackendDescription;
   };
 } {
   return {
-    aliases: MODEL_ALIAS_DETAILS,
+    aliases: getModelAliasDetails(geminiBackend),
     claude: CLAUDE_MODELS,
     codex: CODEX_MODELS,
-    gemini: GEMINI_MODELS,
+    gemini: getGeminiModelsForBackend(geminiBackend),
     forge: FORGE_MODELS,
     opencode: OPENCODE_MODELS,
+    geminiBackend,
+    geminiBackends: {
+      'gemini-cli': {
+        models: GEMINI_MODELS,
+        aliases: MODEL_ALIAS_DETAILS.filter((alias) => alias.agent === 'gemini'),
+        cliBinaryDefault: DEFAULT_GEMINI_CLI_NAME,
+        active: geminiBackend === 'gemini-cli',
+      },
+      antigravity: {
+        models: ANTIGRAVITY_GEMINI_MODELS,
+        aliases: ANTIGRAVITY_MODEL_ALIAS_DETAILS,
+        cliBinaryDefault: DEFAULT_ANTIGRAVITY_CLI_NAME,
+        active: geminiBackend === 'antigravity',
+      },
+    },
     dynamicModelBackends: {
       opencode: {
         explicitPrefix: 'oc-',

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,4 +1,5 @@
 import { debugLog } from './cli-utils.js';
+import type { GeminiBackend } from './model-catalog.js';
 
 export interface PeekMessage {
   ts: string;
@@ -30,6 +31,8 @@ type PeekAgent = 'claude' | 'codex' | string | null;
 interface PeekEventExtractorOptions {
   includeToolCalls?: boolean;
   source?: 'stdout' | 'stderr';
+  /** Only meaningful for the gemini agent; defaults to the Gemini CLI. */
+  geminiBackend?: GeminiBackend;
 }
 
 interface PeekFlushOptions {
@@ -76,6 +79,39 @@ const GEMINI_STREAM_EVENT_TYPES = new Set([
 
 function isGeminiStreamJsonEvent(parsed: any): boolean {
   return parsed && typeof parsed === 'object' && !Array.isArray(parsed) && GEMINI_STREAM_EVENT_TYPES.has(parsed.type);
+}
+
+/**
+ * The Antigravity CLI does not print a conversation id on stdout; it only
+ * mentions it in its internal log, which is why the adapter passes --log-file.
+ */
+export function parseAntigravityConversationId(logText: string): string | null {
+  if (!logText) {
+    return null;
+  }
+
+  let conversationId: string | null = null;
+
+  for (const line of logText.split(/\r?\n/)) {
+    const createdMatch = line.match(/\bCreated conversation ([A-Za-z0-9._:-]+)/);
+    if (createdMatch?.[1]) {
+      conversationId = createdMatch[1];
+      continue;
+    }
+
+    const printModeMatch = line.match(/\bPrint mode: conversation=([A-Za-z0-9._:-]+)/);
+    if (printModeMatch?.[1]) {
+      conversationId = printModeMatch[1];
+      continue;
+    }
+
+    const startingMatch = line.match(/\bconversationID="([^"]+)"/);
+    if (startingMatch?.[1]) {
+      conversationId = startingMatch[1];
+    }
+  }
+
+  return conversationId;
 }
 
 function oneLine(value: unknown): string {
@@ -358,6 +394,7 @@ export class PeekEventExtractor {
   private geminiAssistantBuffer = '';
   private readonly includeToolCalls: boolean;
   private readonly source: 'stdout' | 'stderr';
+  private readonly isAntigravity: boolean;
   private readonly toolMemory = new Map<string, ToolCallMemory>();
   private forgePendingTool: PendingForgeTool | null = null;
   private forgeToolSequence = 0;
@@ -365,10 +402,16 @@ export class PeekEventExtractor {
   constructor(private readonly agent: PeekAgent, options: PeekEventExtractorOptions = {}) {
     this.includeToolCalls = options.includeToolCalls === true;
     this.source = options.source || 'stdout';
+    this.isAntigravity = agent === 'gemini' && options.geminiBackend === 'antigravity';
   }
 
   push(chunk: string, observedAt = new Date().toISOString()): PeekEvent[] {
     if (this.agent === 'forge' && this.source === 'stderr') {
+      return [];
+    }
+
+    // Antigravity writes its internal log lines to stderr; never surface those.
+    if (this.isAntigravity && this.source === 'stderr') {
       return [];
     }
 
@@ -383,6 +426,11 @@ export class PeekEventExtractor {
 
   flush(observedAt = new Date().toISOString(), options: PeekFlushOptions = {}): PeekEvent[] {
     if (this.agent === 'forge' && this.source === 'stderr') {
+      this.pending = '';
+      return [];
+    }
+
+    if (this.isAntigravity && this.source === 'stderr') {
       this.pending = '';
       return [];
     }
@@ -405,6 +453,15 @@ export class PeekEventExtractor {
   private extractLines(lines: string[], observedAt: string): PeekEvent[] {
     if (this.agent === 'forge') {
       return this.extractForgeLines(lines, observedAt);
+    }
+
+    // Antigravity stdout is plain text, so every line is message text - even a
+    // JSON-shaped answer such as {"status":"ok"}, which would otherwise parse
+    // successfully, match no stream event and silently disappear from peek.
+    if (this.isAntigravity) {
+      return lines
+        .filter((line) => line.trim())
+        .map((line) => ({ kind: 'message', ts: observedAt, text: line } as PeekEvent));
     }
 
     const events: PeekEvent[] = [];
@@ -576,8 +633,8 @@ export class PeekEventExtractor {
 export class PeekMessageExtractor {
   private readonly extractor: PeekEventExtractor;
 
-  constructor(agent: PeekAgent) {
-    this.extractor = new PeekEventExtractor(agent, { includeToolCalls: false });
+  constructor(agent: PeekAgent, options: Omit<PeekEventExtractorOptions, 'includeToolCalls'> = {}) {
+    this.extractor = new PeekEventExtractor(agent, { ...options, includeToolCalls: false });
   }
 
   push(chunk: string, observedAt = new Date().toISOString()): PeekMessage[] {
@@ -842,6 +899,21 @@ export function parseGeminiOutput(stdout: string): any {
   }
 
   return null;
+}
+
+/**
+ * Antigravity CLI output: stdout is the plain-text answer and the conversation
+ * id (used to resume with --conversation) comes from the internal log file.
+ */
+export function parseAntigravityOutput(stdout: string, logText = ''): any {
+  const sessionId = parseAntigravityConversationId(logText);
+  const message = typeof stdout === 'string' ? stdout.trim() : '';
+
+  if (!message) {
+    return sessionId ? { message: null, session_id: sessionId } : null;
+  }
+
+  return sessionId ? { message, session_id: sessionId } : { message, session_id: null };
 }
 
 export function parseForgeOutput(stdout: string): any {

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,6 +1,11 @@
 import type { ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
+import type { GeminiBackend } from './model-catalog.js';
+import { parseAntigravityOutput, parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import {
   appendPeekEvents,
   buildNotFoundPeekProcess,
@@ -26,6 +31,9 @@ interface TrackedProcess {
   startTime: string;
   stdout: string;
   stderr: string;
+  /** Antigravity only: path of the CLI log file holding the conversation id. */
+  logPath?: string;
+  geminiBackend?: GeminiBackend | null;
   status: ProcessStatus;
   exitCode?: number;
 }
@@ -47,9 +55,18 @@ interface ProcessServiceOptions {
   cliPaths: BuildCliCommandOptions['cliPaths'];
 }
 
-function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any {
+function parseAgentOutput(
+  agent: AgentType,
+  stdout: string,
+  stderr: string,
+  options: { geminiBackend?: GeminiBackend | null; logText?: string } = {},
+): any {
   if (agent === 'codex') {
     return parseCodexOutput(`${stdout || ''}\n${stderr || ''}`);
+  }
+
+  if (agent === 'gemini' && options.geminiBackend === 'antigravity') {
+    return parseAntigravityOutput(stdout, options.logText || '');
   }
 
   if (!stdout) {
@@ -81,10 +98,22 @@ export class ProcessService {
   }
 
   startProcess(options: Omit<BuildCliCommandOptions, 'cliPaths'>): StartProcessResult {
-    const cmd = buildCliCommand({
+    let cmd = buildCliCommand({
       ...options,
       cliPaths: this.cliPaths,
     });
+
+    // Antigravity prints no conversation id on stdout, so it is asked to write
+    // its internal log to a file the adapter can read the id back from.
+    let logPath: string | undefined;
+    if (cmd.geminiBackend === 'antigravity') {
+      logPath = this.createAntigravityLogPath();
+      cmd = buildCliCommand({
+        ...options,
+        log_file: logPath,
+        cliPaths: this.cliPaths,
+      });
+    }
 
     const { cliPath, args: processArgs, cwd: effectiveCwd, agent, prompt } = cmd;
     let childProcess: ChildProcess;
@@ -121,6 +150,8 @@ export class ProcessService {
       startTime: new Date().toISOString(),
       stdout: '',
       stderr: '',
+      logPath,
+      geminiBackend: cmd.geminiBackend,
       status: 'running',
     };
 
@@ -176,7 +207,10 @@ export class ProcessService {
       throw new Error(`Process with PID ${pid} not found`);
     }
 
-    const agentOutput = parseAgentOutput(process.toolType, process.stdout, process.stderr);
+    const agentOutput = parseAgentOutput(process.toolType, process.stdout, process.stderr, {
+      geminiBackend: process.geminiBackend,
+      logText: process.logPath ? readTextFileSafe(process.logPath) : '',
+    });
 
     return buildProcessResult({
       pid,
@@ -262,8 +296,16 @@ export class ProcessService {
       };
       processes.push(result);
 
-      const stdoutExtractor = new PeekEventExtractor(entry.toolType, { includeToolCalls, source: 'stdout' });
-      const stderrExtractor = new PeekEventExtractor(entry.toolType, { includeToolCalls, source: 'stderr' });
+      const stdoutExtractor = new PeekEventExtractor(entry.toolType, {
+        includeToolCalls,
+        source: 'stdout',
+        geminiBackend: entry.geminiBackend ?? undefined,
+      });
+      const stderrExtractor = new PeekEventExtractor(entry.toolType, {
+        includeToolCalls,
+        source: 'stderr',
+        geminiBackend: entry.geminiBackend ?? undefined,
+      });
       const onStdout = (data: Buffer | string) => {
         appendPeekEvents(result, stdoutExtractor.push(data.toString(), new Date().toISOString()));
       };
@@ -361,6 +403,9 @@ export class ProcessService {
     for (const [pid, process] of this.processManager.entries()) {
       if (process.status === 'completed' || process.status === 'failed') {
         removedPids.push(pid);
+        if (process.logPath) {
+          removeFileSafe(process.logPath);
+        }
         this.processManager.delete(pid);
       }
     }
@@ -370,5 +415,30 @@ export class ProcessService {
       removedPids,
       message: `Cleaned up ${removedPids.length} finished process(es)`,
     };
+  }
+
+  private createAntigravityLogPath(): string {
+    return join(tmpdir() || '.', `ai-cli-mcp-antigravity-${randomUUID()}.log`);
+  }
+}
+
+function readTextFileSafe(filePath: string): string {
+  if (!existsSync(filePath)) {
+    return '';
+  }
+
+  try {
+    const text = readFileSync(filePath, 'utf-8');
+    return typeof text === 'string' ? text : '';
+  } catch {
+    return '';
+  }
+}
+
+function removeFileSafe(filePath: string): void {
+  try {
+    rmSync(filePath, { force: true });
+  } catch {
+    // Best effort: a leftover temp log must never fail cleanup.
   }
 }


### PR DESCRIPTION
## Summary

Adds the Antigravity CLI (`agy`) as an **optional, opt-in backend** for the `gemini` agent, selected with a new `GEMINI_CLI_BACKEND` environment variable. The default is `gemini-cli`, so installations that do not set the variable are byte-for-byte unchanged.

This supersedes #54, which was correctly rejected as a breaking replacement. This PR is a rewrite from scratch on top of `develop` (v2.23.0) and is scoped to Gemini only — it contains no Codex changes.

**Problem.** The `gemini` agent can only target the Gemini CLI. Users who run Google's Antigravity CLI have no way to reach it through this server: the Gemini CLI argument shape (`-y`, `--output-format stream-json`) is not accepted by `agy`, which is a different binary with a different argument surface, plain-text stdout, and its own conversation IDs.

**Solution.** Introduce the backend as a distinct configuration rather than a replacement:

| | `gemini-cli` (default) | `antigravity` |
|---|---|---|
| Binary default | `gemini` | `agy` (official) |
| Arguments | unchanged | `--dangerously-skip-permissions --print-timeout … --model … -p` |
| Model catalog | unchanged legacy catalog | Antigravity display names |
| Output parsing | unchanged (stream JSON) | plain text + conversation ID |
| `reasoning_effort` | unsupported (unchanged) | `low` \| `medium` \| `high` |

`GEMINI_CLI_BACKEND` accepts `gemini-cli`, `antigravity`, or `auto` (picks Antigravity when the resolved Gemini command's basename is `agy`/`agy-*`). An invalid value fails fast at startup with an explicit message.

Requesting a model from the wrong backend is an explicit error rather than a silent fallback:

```
Model "gemini-3.8-flash-high" belongs to the antigravity Gemini backend and requires
GEMINI_CLI_BACKEND=antigravity. The active Gemini backend is gemini-cli.
```

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Refactoring
- [x] docs: Documentation
- [x] test: Add or update tests
- [ ] chore: Build, CI, dependencies, etc.

## Changes

- `GEMINI_CLI_BACKEND` selection (`gemini-cli` | `antigravity` | `auto`), validated at startup and at command build time
- Separate Antigravity model catalog and lowercase aliases; the legacy `GEMINI_MODELS` and `MODEL_ALIASES` are untouched
- `gemini-ultra` keeps its legacy meaning on the default backend and resolves to `Gemini 3.1 Pro (High)` on Antigravity
- Antigravity argument builder, plain-text output parser, and conversation-ID extraction, all selected per backend
- `reasoning_effort` support for the Antigravity backend, resolving to the corresponding model variant (the level is part of the `agy` model name, so no `--effort` flag is passed)
- `models` tool exposes `geminiBackend` and both catalogs under `geminiBackends`, while the existing `gemini` key keeps returning the active backend's list
- Docs: both READMEs, `CONTRIBUTING.md` environment table, `docs/development.md`

## Addressing the review on #54

1. **[P1] Undocumented local wrapper binary.** Fixed. The default Gemini binary is still `gemini`. Only `GEMINI_CLI_BACKEND=antigravity` switches it, and to the official `agy` — the local wrapper is gone from the codebase entirely. `doctor` only looks for `agy` once the backend is selected, so nothing new is reported as unavailable for users who did not opt in.
2. **[P1] Breaking replacement rather than additive support.** Fixed by the backend design above. `GEMINI_CLI_NAME=gemini` alone still behaves exactly as before, because the builder no longer emits Antigravity flags on the default backend.
3. **[P2] Codex reasoning capabilities over-advertised.** Out of scope now — this PR contains no Codex catalog or effort changes at all.
4. **[P2] JSON-shaped Antigravity text disappearing from peek.** Fixed. On the Antigravity path `PeekEventExtractor` emits every non-empty stdout line as message text with no `JSON.parse` gate, so a response like `{"status":"ok"}` is no longer swallowed, while stderr log lines stay suppressed. Covered by a dedicated test.

## Relation to #19

This partially addresses #19 (thinking/effort control for Gemini), but only for the Antigravity backend, and by selecting the model variant rather than by a thinking-budget flag. `Gemini 3.1 Pro` only publishes `low`/`high`. Nothing changes for the Gemini CLI itself, so #19 should stay open.

## Test Plan

- [x] `npm run test:release` passes (deterministic gate; real live E2E is separate) — 352 passed, 15 skipped, plus the package smoke test
- [ ] Release-time live E2E passes when the change can affect CLI execution
- [x] Manual testing (if applicable)

**No existing test needed changes.** The only test files in the diff are the two new ones. Non-regression is asserted explicitly: with `GEMINI_CLI_BACKEND` unset, the `gemini` agent still builds the Gemini CLI arguments, keeps the legacy catalog, and rejects `reasoning_effort` with the current message.

**How to review without installing `agy`:** the entire default path is exercised by the existing suite, and `src/__tests__/gemini-backend.test.ts` pins the unchanged default. The Antigravity path is covered by deterministic argument/parser tests that never spawn a real binary, so `npm run test:release` is fully reproducible on a machine that has no Antigravity CLI. `ai-cli models` with no environment variables set returns the same payload as before, now with an added `geminiBackend: "gemini-cli"` field.

**Manual verification against the real CLI** (Antigravity CLI installed as the official `agy`, no wrapper): `ai-cli run --model gemini-3.8-flash --reasoning-effort medium` completed with `exitCode: 0` and returned the model's answer plus a conversation ID; `low` and `high` were exercised the same way.

## Notes

For existing users the intended change is **none**. If you would rather gate this differently — a config field instead of an environment variable, or a separate agent name such as `antigravity` instead of a backend of `gemini` — I am happy to rework it; the backend boundary is already isolated behind one resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aNzfRF34CQyNxtU8Lsche
